### PR TITLE
Fix count when armor is destroyed.

### DIFF
--- a/3d_armor/api.lua
+++ b/3d_armor/api.lua
@@ -316,6 +316,8 @@ armor.punch = function(self, player, hitter, time_from_last_punch, tool_capabili
 	if not name then
 		return
 	end
+	local set_state
+	local set_count
 	local state = 0
 	local count = 0
 	local recip = true
@@ -376,10 +378,16 @@ armor.punch = function(self, player, hitter, time_from_last_punch, tool_capabili
 			end
 			if damage == true then
 				self:damage(player, i, stack, use)
+				set_state = self.def[name].state
+				set_count = self.def[name].count
 			end
 			state = state + stack:get_wear()
 			count = count + 1
 		end
+	end
+	if set_count and set_count ~= count then
+		state = set_state or state
+		count = set_count or count
 	end
 	self.def[name].state = state
 	self.def[name].count = count


### PR DESCRIPTION
This fixes a subtle bug I found when using the hbarmor mod which provides a hudbar for 3d_armor.

https://repo.or.cz/w/minetest_hbarmor.git

The basic problem is that when armor is destroyed through wear the hudbar shows the amount of armor as if it was new even if the armor inventory no longer has the broken item or is entirely empty.

After looking at both hbarmor and 3d_armor I found the problem is because hbarmor relies on the `armor.def[playername].count` from 3d_armor.

https://repo.or.cz/minetest_hbarmor.git/blob/93d994cbad6a16f985919add5776b568d7a5d6d3:/init.lua#l36

In 3d_armor when armor is destroyed it will be correctly set in `armor.set_player_armor()`.

https://github.com/minetest-mods/3d_armor/blob/c3a755518ebb42f2fea8fcf21cedff56731efd92/3d_armor/api.lua#L310

And when the armor is damaged it will be again set in `armor.punch()`.

https://github.com/minetest-mods/3d_armor/blob/c3a755518ebb42f2fea8fcf21cedff56731efd92/3d_armor/api.lua#L385

The problem is:

*  `armor.punch()` sets the armor count and state based on the current armor in the inventory.
* `armor.punch()` calls `armor.damage()` which calls `armor.set_player_armor()` and sets the new armor correct armor count and state if the current armor is destroyed.

https://github.com/minetest-mods/3d_armor/blob/c3a755518ebb42f2fea8fcf21cedff56731efd92/3d_armor/api.lua#L378

https://github.com/minetest-mods/3d_armor/blob/c3a755518ebb42f2fea8fcf21cedff56731efd92/3d_armor/api.lua#L396

* Now `armor.punch()` ignores the new correct count and proceeds to set the armor count and state as if it was never destroyed.

I now made it use `self.def[name].count` and `self.def[name].state` when the count differs from the count in `armor.punch()` so that the hudbar will update correctly when armor is destroyed. When they do not differ the count and state set in `armor.punch()` is used like the current behavior.
