### PR TITLE
Don't damage armor when drowning, eating or starving.

### DIFF
--- a/3d_armor/init.lua
+++ b/3d_armor/init.lua
@@ -392,8 +392,9 @@ if armor.config.punch_damage == true then
 	end)
 end
 
-minetest.register_on_player_hpchange(function(player, hp_change)
-	if player and hp_change < 0 then
+minetest.register_on_player_hpchange(function(player, hp_change, reason)
+	if player and reason.type ~= "drown" and reason.hunger == nil
+			and hp_change < 0 then
 		local name = player:get_player_name()
 		if name then
 			local heal = armor.def[name].heal


### PR DESCRIPTION
Fixes https://github.com/stujones11/minetest-3d_armor/issues/119.

Note for a hunger mod to properly support this they must give the reason when changing the player's health. The changes for the `hunger_ng` mod were merged, but I haven't looked at any other hunger mods.

https://gitlab.com/4w/hunger_ng/-/merge_requests/8
https://gitlab.com/4w/hunger_ng/-/commit/7a0c18cdd8b1385c6e145a68b40cbbe3a27c2174

Instead of checking the specific reason, I am checking only weather `reason.hunger` is `nil` or not. I think armor should not be damaged from eating foods or starving regardless of the reason?