### PR TITLE
Add missing fuel recipes for wood and cactus armor.

### DIFF
--- a/3d_armor/armor.lua
+++ b/3d_armor/armor.lua
@@ -79,6 +79,19 @@ if armor.materials.wood then
 		damage_groups = {cracky=3, snappy=2, choppy=3, crumbly=2, level=1},
 		groups = {armor_feet=1, armor_heal=0, armor_use=2000, flammable=1},
 	})
+	local wood_armor_fuel = {
+		helmet = 6,
+		chestplate = 8,
+		leggings = 7,
+		boots = 5
+	}
+	for armor, burn in pairs(wood_armor_fuel) do
+		minetest.register_craft({
+			type = "fuel",
+			recipe = "3d_armor:" .. armor .. "_wood",
+			burntime = burn,
+		})
+	end
 end
 
 if armor.materials.cactus then
@@ -110,6 +123,19 @@ if armor.materials.cactus then
 		armor_groups = {fleshy=5},
 		damage_groups = {cracky=3, snappy=3, choppy=2, crumbly=2, level=1},
 	})
+	local cactus_armor_fuel = {
+		helmet = 14,
+		chestplate = 16,
+		leggings = 15,
+		boots = 13
+	}
+	for armor, burn in pairs(cactus_armor_fuel) do
+		minetest.register_craft({
+			type = "fuel",
+			recipe = "3d_armor:" .. armor .. "_cactus",
+			burntime = burn,
+		})
+	end
 end
 
 if armor.materials.steel then

--- a/shields/init.lua
+++ b/shields/init.lua
@@ -68,6 +68,11 @@ if armor.materials.wood then
 			{"default:steel_ingot"},
 		},
 	})
+	minetest.register_craft({
+		type = "fuel",
+		recipe = "shields:shield_wood",
+		burntime = 8,
+	})
 end
 
 if armor.materials.cactus then
@@ -106,6 +111,11 @@ if armor.materials.cactus then
 			{"shields:shield_cactus"},
 			{"default:steel_ingot"},
 		},
+	})
+	minetest.register_craft({
+		type = "fuel",
+		recipe = "shields:shield_cactus",
+		burntime = 16,
 	})
 end
 


### PR DESCRIPTION
Fixes https://github.com/stujones11/minetest-3d_armor/issues/174

This adds fuel recipes for all of the wooden and cactus armor excluding the enhanced shields. I tried to use the wiki to balance the burn times correctly, but please suggest better fuel times if you feel appropriate.

https://wiki.minetest.net/Smelting