### PR TITLE
Italian translation corrections + armor:remove_all

### DIFF
--- a/3d_armor/README.txt
+++ b/3d_armor/README.txt
@@ -162,7 +162,7 @@ and so should NOT be called from `on_unequip` to avoid an infinite loop.
 
 armor:remove_all(player)
 
-Remove all armors from the player's inventory without triggering any callback.
+Removes all armors from the player's inventory without triggering any callback.
 
 Item Callbacks:
 

--- a/3d_armor/README.txt
+++ b/3d_armor/README.txt
@@ -160,6 +160,10 @@ Adds wear to a single armor itemstack, triggers `on_damage` callbacks and
 updates the necessary inventories. Also handles item destruction callbacks
 and so should NOT be called from `on_unequip` to avoid an infinite loop.
 
+armor:remove_all(player)
+
+Remove all armors from the player's inventory without triggering any callback.
+
 Item Callbacks:
 
 on_equip = func(player, index, stack)

--- a/3d_armor/api.lua
+++ b/3d_armor/api.lua
@@ -406,6 +406,16 @@ armor.damage = function(self, player, index, stack, use)
 	end
 end
 
+armor.remove_all = function(self, player)
+    local name, armor_inv = self.get_valid_player(player, "[remove_all]")
+	if not name then
+		return
+    end
+	armor_inv:set_list("armor", {})
+	self.set_player_armor(player)
+	self.save_armor_inventory(player)
+end
+
 armor.get_player_skin = function(self, name)
 	if (self.skin_mod == "skins" or self.skin_mod == "simple_skins") and skins.skins[name] then
 		return skins.skins[name]..".png"

--- a/3d_armor/api.lua
+++ b/3d_armor/api.lua
@@ -407,13 +407,13 @@ armor.damage = function(self, player, index, stack, use)
 end
 
 armor.remove_all = function(self, player)
-    local name, armor_inv = self.get_valid_player(player, "[remove_all]")
+    local name, armor_inv = self:get_valid_player(player, "[remove_all]")
 	if not name then
 		return
     end
 	armor_inv:set_list("armor", {})
-	self.set_player_armor(player)
-	self.save_armor_inventory(player)
+	self:set_player_armor(player)
+	self:save_armor_inventory(player)
 end
 
 armor.get_player_skin = function(self, name)

--- a/3d_armor/locale/3d_armor.it.tr
+++ b/3d_armor/locale/3d_armor.it.tr
@@ -3,9 +3,9 @@
 
 ### api.lua ###
 
-3d_armor: Detached armor inventory is nil @1=3d_armor: L'inventario staccato dell'armatura è nullo @1
-3d_armor: Player name is nil @1=3d_armor: Il nome della/del gicatrice/tore è nullo @1
-3d_armor: Player reference is nil @1=3d_armor: Il riferimento alla/al giocatrice/tore è nullo @1
+3d_armor: Detached armor inventory is nil @1=3d_armor: L'inventario separato dell'armatura è nullo @1
+3d_armor: Player name is nil @1=3d_armor: Il nome dell'utente è nullo @1
+3d_armor: Player reference is nil @1=3d_armor: Il riferimento all'utente è nullo @1
 
 ### armor.lua ###
 
@@ -37,10 +37,10 @@ Mithril Boots=Stivali di mithril
 Mithril Chestplate=Corazza di mithril
 Mithril Helmet=Elmo di mithril
 Mithril Leggings=Gambali di mithril
-Steel Boots=Stivali di acciaio
-Steel Chestplate=Corazza di acciaio
-Steel Helmet=Elmo di acciaio
-Steel Leggings=Gambali di acciaio
+Steel Boots=Stivali d'acciaio
+Steel Chestplate=Corazza d'acciaio
+Steel Helmet=Elmo d'acciaio
+Steel Leggings=Gambali d'acciaio
 Wood Boots=Stivali di legno
 Wood Chestplate=Corazza di legno
 Wood Helmet=Elmo di legno
@@ -48,28 +48,28 @@ Wood Leggings=Gambali di legno
 
 ### init.lua ###
 
-3d_armor: Failed to initialize player=3d_armor: Inizializzazione della/del giocatrice/tore fallita
+3d_armor: Failed to initialize player=3d_armor: Inizializzazione dell'utente fallita
 Fire=Fuoco
 Heal=Guarigione
 Level=Livello
 Radiation=Radiazione
-Your @1 got destroyed!=Il/i vostro/i @1 è/sono stato/i distrutto/i!
-Your @1 is almost broken!=
+Your @1 got destroyed!=@1 distrutto/a/i!
+Your @1 is almost broken!=@1 quasi distrutto/a/i
 [3d_armor] Fire Nodes disabled=[3d_armor] Nodi fuoco disabilitati
 
 
 ##### not used anymore #####
 
-3d_armor_ip: Mod loaded but unused.=3d_armor_ip: Mod caricato ma inutilizzato.
+3d_armor_ip: Mod loaded but unused.=3d_armor_ip: Mod caricata ma inutilizzata.
 Back=Indietro
 Armor=Armatura
-3d_armor_sfinv: Mod loaded but unused.=3d_armor_sfinv: Mod caricato ma inutilizzato.
+3d_armor_sfinv: Mod loaded but unused.=3d_armor_sfinv: Mod caricata ma inutilizzata.
 Armor stand top=Parte superiore del supporto per armatura
 Armor stand=Supporto per armatura
 Armor Stand=Supporto per armatura
 Locked Armor stand=Supporto per armatura chiuso a chiave
 Armor Stand (owned by @1)=Supporto per armatura (di proprietà di @1)
-3d_armor_ui: Mod loaded but unused.=3d_armor_ui: Mod caricato ma inutilizzato.
+3d_armor_ui: Mod loaded but unused.=3d_armor_ui: Mod caricata ma inutilizzata.
 3d Armor=Armatura 3D
 Armor not initialized!=Armatura non inizializzata!
 Admin Shield=Scudo dell'amministratrice/tore
@@ -77,7 +77,7 @@ Wooden Shield=Scudo di legno
 Enhanced Wood Shield=Scudo di legno migliorato
 Cactus Shield=Scudo di cactus
 Enhanced Cactus Shield=Scudo di cactus migliorato
-Steel Shield=Scudo di acciaio
+Steel Shield=Scudo d'acciaio
 Bronze Shield=Scudo di bronzo
 Diamond Shield=Scudo di diamante
 Gold Shield=Scudo d'oro

--- a/3d_armor/locale/3d_armor.it.tr
+++ b/3d_armor/locale/3d_armor.it.tr
@@ -53,8 +53,8 @@ Fire=Fuoco
 Heal=Guarigione
 Level=Livello
 Radiation=Radiazione
-Your @1 got destroyed!=@1 distrutto/a/i!
-Your @1 is almost broken!=@1 quasi distrutto/a/i
+Your @1 got destroyed!=@1 in frantumi!
+Your @1 is almost broken!=@1 quasi in frantumi!
 [3d_armor] Fire Nodes disabled=[3d_armor] Nodi fuoco disabilitati
 
 

--- a/wieldview/README.txt
+++ b/wieldview/README.txt
@@ -21,3 +21,7 @@ Wield image transformation: To apply a simple transformation to the item in
 hand, add the group “wieldview_transform” to the item definition. The group
 rating equals one of the numbers used for the [transform texture modifier
 of the Lua API.
+
+Disabling the feature in-game: If you want to hide the wielded item
+you can add an INT metadata to the player called "show_wielded_item" and set
+it to 2 (any other value will show the wielded item again)

--- a/wieldview/README.txt
+++ b/wieldview/README.txt
@@ -24,4 +24,4 @@ of the Lua API.
 
 Disabling the feature in-game: If you want to hide the wielded item
 you can add an INT metadata to the player called "show_wielded_item" and set
-it to 2 (any other value will show the wielded item again)
+it to 2 (any other value will show the wielded item again).

--- a/wieldview/init.lua
+++ b/wieldview/init.lua
@@ -60,7 +60,6 @@ wieldview.update_wielded_item = function(self, player)
 		if self.wielded_item[name] == item then
 			return
 		end
-		
 		armor.textures[name].wielditem = self:get_item_texture(item)
 		armor:update_player_visuals(player)
 	end

--- a/wieldview/init.lua
+++ b/wieldview/init.lua
@@ -54,9 +54,13 @@ wieldview.update_wielded_item = function(self, player)
 		return
 	end
 	if self.wielded_item[name] then
+		if player:get_meta():get_int("show_wielded_item") == 2 then
+			item = ""
+		end
 		if self.wielded_item[name] == item then
 			return
 		end
+		
 		armor.textures[name].wielditem = self:get_item_texture(item)
 		armor:update_player_visuals(player)
 	end


### PR DESCRIPTION
- Corrected the italian translation (there were some missing/wrong strings, and other that could have been simplified) 
- Added armor:remove_all(player), a useful function that allows to fastly remove all players' armors without calling any callback.