### PR TITLE
reset undropped armor

### DIFF
--- a/3d_armor/init.lua
+++ b/3d_armor/init.lua
@@ -389,6 +389,10 @@ if armor.config.drop == true or armor.config.destroy == true then
 			end)
 		end
 	end)
+else -- reset un-dropped armor and it's effects
+	minetest.register_on_respawnplayer(function(player)
+		armor:set_player_armor(player)
+	end)
 end
 
 if armor.config.punch_damage == true then


### PR DESCRIPTION
if armor doesnt drop when player dies as per setting, this change resets player effects like speed, gravity, jump etc. which fixes a bug found by players.