### PR TITLE
fix for #30 Shield hardsets multiplier to 0.9 for all armor items

### DIFF
--- a/shields/init.lua
+++ b/shields/init.lua
@@ -17,8 +17,6 @@ end
 
 if minetest.global_exists("armor") and armor.elements then
 	table.insert(armor.elements, "shield")
-	local mult = armor.config.level_multiplier or 1
-	armor.config.level_multiplier = mult * 0.9
 end
 
 -- Regisiter Shields


### PR DESCRIPTION
2 line update so that shields when used no longer affects the base armor.config.level_multiplier and hard sets this to 0.9 and overriding whatever value maybe set under the UI for this seeting.

Tested in combination with #34 but no issues detected

Hopefully Ive done this correctly and seperated the two changes correctly.