### PR TITLE
Add armor set and armor set bonus setting

### DIFF
--- a/3d_armor/README.md
+++ b/3d_armor/README.md
@@ -98,7 +98,7 @@ Change the following default settings by going to Main Menu>>Settings(Tab)>>All 
 	
 ### Allows the customisation of armor set 
  **Shields already configured as need to be worn to complete an armor set**   
- **These names come from [Groups used by 3d_Armor](#groups-used-by-3d_armor), the second half of the element name eg armor_head is head**
+ **These names come from [Element names](#groups-used-by-3d_armor), the second half of the element name only is used eg armor_head is head**
  
     armor_set_elements = head torso legs feet shield
 

--- a/3d_armor/README.md
+++ b/3d_armor/README.md
@@ -5,24 +5,24 @@
 |-[Overview](#overview)                                                      |||-[API](#api)|
 |-[Armor Configuration](#armor-configuration)                                |||- - [3d_Armor Item Storage](#3d_armor-item-storage)
 |- - [disable_specific_materials](#to-disable-individual-armor-materials)    |||- - [Armor Registration](#armor-registration)
-|- - [armor_init_delay](#initialization-glitches-when-a-player-first-joins)  |||- - [Registering Armor Groups](#registering-armor-groups)
-|- - [armor_init_times](#number-of-initialization-attempts)                  |||- - [Groups used by 3d_Armor](#groups-used-by-3d_armor)
-|- - [armor_bones_delay](#armor-not-in-bones-due-to-server-lag)              |||- - - [Elements](#elements)
-|- - [armor_update_time](#how-often-player-armor-items-are-updated)          |||- - - [Attributes](#attributes)
-|- - [armor_drop](#drop-armor-when-a-player-dies)                            |||- - - [Physics](#physics)
-|- - [armor_destroy](#destroy-armor-when-a-player-dies)                      |||- - - [Durability](#durability)
-|- - [armor_level_multiplier](#armor-level-multiplyer)                       |||- - [Armour Functions](#armour-functions)
-|- - [armor_heal_multiplier](#armor-healing-multiplyer)                      |||- - - [armor:set_player_armor](#armor-set_player_armor)
-|- - [armor_water_protect](#enable-water-protection)                         |||- - - [armor:punch](#armor-punch)
-|- - [armor_fire_protect](#enable-fire-protection)                           |||- - - [armor:damage](#armor-damage)
-|- - [armor_punch_damage](#enable-punch-damage-effects)                      |||- - - [armor:remove_all](#armor-remove_all)
-|- - [armor_migrate_old_inventory](#migration-of-old-armor-inventories)      |||- - - [armor:equip](#armor-equip)
-|- - [wieldview_update_time](#how-often-player-wield-items-are-updated)      |||- - - [armor:unequip](#armor-unequip)
-| - [Credits](#credits)                                                      |||- - - [armor:update_skin](#armor-update_skin)
-|                                                                            |||- - [Callbacks](#Callbacks)
+|- - [armor_set_elements](#allows-the-customisation-of-armor-set)            |||- - [Registering Armor Groups](#registering-armor-groups)
+|- - [armor_set_bonus](#armor-set-bonus-multiplier )                         |||- - [Groups used by 3d_Armor](#groups-used-by-3d_armor)
+|- - [armor_init_delay](#initialization-glitches-when-a-player-first-joins)  |||- - - [Elements](#elements)
+|- - [armor_init_times](#number-of-initialization-attempts)                  |||- - - [Attributes](#attributes)
+|- - [armor_bones_delay](#armor-not-in-bones-due-to-server-lag)              |||- - - [Physics](#physics)
+|- - [armor_update_time](#how-often-player-armor-items-are-updated)          |||- - - [Durability](#durability)
+|- - [armor_drop](#drop-armor-when-a-player-dies)                            |||- - - [Armor Material](#armor-material)
+|- - [armor_destroy](#destroy-armor-when-a-player-dies)                      |||- - [Armour Functions](#armor-functions)
+|- - [armor_level_multiplier](#armor-level-multiplyer)                       |||- - - [armor:set_player_armor](#armor-set_player_armor)
+|- - [armor_heal_multiplier](#armor-healing-multiplyer)                      |||- - - [armor:punch](#armor-punch)
+|- - [armor_water_protect](#enable-water-protection)                         |||- - - [armor:damage](#armor-damage)
+|- - [armor_fire_protect](#enable-fire-protection)                           |||- - - [armor:remove_all](#armor-remove_all)
+|- - [armor_punch_damage](#enable-punch-damage-effects)                      |||- - - [armor:equip](#armor-equip)
+|- - [armor_migrate_old_inventory](#migration-of-old-armor-inventories)      |||- - - [armor:unequip](#armor-unequip)
+|- - [wieldview_update_time](#how-often-player-wield-items-are-updated)      |||- - - [armor:update_skin](#armor-update_skin)
+|-[Credits](#credits)                                                        |||- - [Callbacks](#Callbacks)
 |                                                                            |||- - - [Item callbacks](#item-callbacks)
 |                                                                            |||- - - [Global callbacks](#global-callbacks)
-
 # Overview
 
 **Depends:** default
@@ -52,6 +52,16 @@ Override the following default settings by adding them to your ***minetest.conf*
     armor_material_gold = true
     armor_material_mithril = true
     armor_material_crystal = true
+
+### Allows the customisation of armor set 
+ **Shields already configured as part of the set**
+ 
+    armor_set_elements = head torso legs feet shield
+
+### Armor set bonus multiplier 
+ **Set to 1 to disable set bonus**
+ 
+    armor_set_multiplier = 1.1
 
 ### Initialization glitches when a player first joins
  **Increase to prevent glitches**
@@ -350,7 +360,42 @@ Durability is determined by the value assigned to the group ***armor_use***. The
  All diamond armor items have an  ***armor_use=200***;
  
 	65535/2000 = 327.6 (327)   
- After 327 uses(hits) the armor item will break.   
+ After 327 uses(hits) the armor item will break. 
+
+### Armor Material 
+The material the armor is made from is defined by adding the material to the end of register armor item name. It is very important the material is the last item in the registered item name and it is preceeded by an "_", "_materialname".
+The material name is what 3d_armor uses to determine if a player is wearing a set of armor, all items worn that are configured as an item to be included in the set check must be made of the same material for the player to recieve a set armor bonus.
+
+So to get a set bonus under the default set settings the players armor items listed below must be made of the same material:
+head - Helmet   
+torso - Chestplate   
+legs - Leggings   
+feet - Boots   
+shield - Shields   
+
+If all of the above were made of material wood the player wood recieve a ***armor_set_bonus*** of armor_level * 1.1   
+
+ **Example One** 
+ 
+	armor:register_armor("3d_armor:helmet_bronze", {
+		description = S("Bronze Helmet"),
+		inventory_image = "3d_armor_inv_helmet_bronze.png",
+		groups = {armor_head=1, armor_heal=6, armor_use=400, physics_speed=-0.01, physics_gravity=0.01},
+		armor_groups = {fleshy=10},
+		damage_groups = {cracky=3, snappy=2, choppy=2, crumbly=1, level=2},
+	})
+	
+ **Example One** 
+ 
+	armor:register_armor("new_mod:helmet_spartan_bronze", {
+		description = S("Bronze Helmet"),
+		inventory_image = "new_mod_inv_helmet_spartan_bronze.png",
+		groups = {armor_head=1, armor_heal=6, armor_use=350, physics_speed=-0.01, physics_gravity=0.01},
+		armor_groups = {fleshy=12},
+		damage_groups = {cracky=3, snappy=2, choppy=2, crumbly=1, level=2},
+	})
+
+***Note: At the moment an armor can only be made of one material***
 
 ## Armor Functions
 

--- a/3d_armor/README.md
+++ b/3d_armor/README.md
@@ -2,27 +2,27 @@
 
 |  |  |  |  | 
 |--|--|--|--|
-|-[Overview](#overview)														|||-[API](#api)
-|-[Armor Configuration](#armor-configuration)								|||- - [3d_Armor Item Storage](#3d_armor-item-storage)
-|- - [disable_specific_materials](#to-disable-individual-armor-materials)	|||- - [Armor Registration](#armor-registration)
-|- - [armor_init_delay](#initialization-glitches-when-a-player-first-joins)	|||- - [Registering Armor Groups](#registering-armor-groups)
-|- - [armor_init_times](#number-of-initialization-attempts)					|||- - [Groups used by 3d_Armor](#groups-used-by-3d_armor)
-|- - [armor_bones_delay](#armor-not-in-bones-due-to-server-lag)				|||- - - [Elements](#elements)
-|- - [armor_update_time](#how-often-player-armor-items-are-updated)			|||- - - [Attributes](#attributes)
-|- - [armor_drop](#drop-armor-when-a-player-dies)							|||- - - [Physics](#physics)
-|- - [armor_destroy](#destroy-armor-when-a-player-dies)						|||- - - [Durability](#durability)
-|- - [armor_level_multiplier](#armor-level-multiplyer)						|||- - - [Armor Material](#armor-material)
-|- - [armor_heal_multiplier](#armor-healing-multiplyer)						|||- - [Armour Functions](#armor-functions)
-|- - [armor_set_elements](#allows-the-customisation-of-armor-set)			|||- - - [armor:set_player_armor](#armor-set_player_armor)
-|- - [armor_set_bonus](#armor-set-bonus-multiplier )						|||- - - [armor:punch](#armor-punch)
-|- - [armor_water_protect](#enable-water-protection)						|||- - - [armor:damage](#armor-damage)
-|- - [armor_fire_protect](#enable-fire-protection)							|||- - - [armor:remove_all](#armor-remove_all)
-|- - [armor_punch_damage](#enable-punch-damage-effects)						|||- - - [armor:equip](#armor-equip)
-|- - [armor_migrate_old_inventory](#migration-of-old-armor-inventories)		|||- - - [armor:unequip](#armor-unequip)
-|- - [wieldview_update_time](#how-often-player-wield-items-are-updated)		|||- - - [armor:update_skin](#armor-update_skin)
-|-[Credits](#credits)														|||- - [Callbacks](#Callbacks)
-|																			|||- - - [Item callbacks](#item-callbacks)
-|																			|||- - - [Global callbacks](#global-callbacks)
+|-[Overview](#overview)                                                     |||-[API](#api)
+|-[Armor Configuration](#armor-configuration)                               |||- - [3d_Armor Item Storage](#3d_armor-item-storage)
+|- - [disable_specific_materials](#to-disable-individual-armor-materials)   |||- - [Armor Registration](#armor-registration)
+|- - [armor_init_delay](#initialization-glitches-when-a-player-first-joins) |||- - [Registering Armor Groups](#registering-armor-groups)
+|- - [armor_init_times](#number-of-initialization-attempts)                 |||- - [Groups used by 3d_Armor](#groups-used-by-3d_armor)
+|- - [armor_bones_delay](#armor-not-in-bones-due-to-server-lag)             |||- - - [Elements](#elements)
+|- - [armor_update_time](#how-often-player-armor-items-are-updated)         |||- - - [Attributes](#attributes)
+|- - [armor_drop](#drop-armor-when-a-player-dies)                           |||- - - [Physics](#physics)
+|- - [armor_destroy](#destroy-armor-when-a-player-dies)                     |||- - - [Durability](#durability)
+|- - [armor_level_multiplier](#armor-level-multiplyer)                      |||- - - [Armor Material](#armor-material)
+|- - [armor_heal_multiplier](#armor-healing-multiplyer)                     |||- - [Armour Functions](#armor-functions)
+|- - [armor_set_elements](#allows-the-customisation-of-armor-set)           |||- - - [armor:set_player_armor](#armor-set_player_armor)
+|- - [armor_set_bonus](#armor-set-bonus-multiplier)                         |||- - - [armor:punch](#armor-punch)
+|- - [armor_water_protect](#enable-water-protection)                        |||- - - [armor:damage](#armor-damage)
+|- - [armor_fire_protect](#enable-fire-protection)                          |||- - - [armor:remove_all](#armor-remove_all)
+|- - [armor_punch_damage](#enable-punch-damage-effects)                     |||- - - [armor:equip](#armor-equip)
+|- - [armor_migrate_old_inventory](#migration-of-old-armor-inventories)     |||- - - [armor:unequip](#armor-unequip)
+|- - [wieldview_update_time](#how-often-player-wield-items-are-updated)     |||- - - [armor:update_skin](#armor-update_skin)
+|-[Credits](#credits)                                                       |||- - [Callbacks](#Callbacks)
+|                                                                           |||- - - [Item callbacks](#item-callbacks)
+|                                                                           |||- - - [Global callbacks](#global-callbacks)
 
 # Overview
 
@@ -186,7 +186,7 @@ Wrapper function for `minetest.register_tool`, which enables the easy registrati
     	preview = "mod_name_leather_chestplate_preview.png",
     	groups = {armor_torso=1, armor_heal=0, armor_use=2000, flammable=1},
     	armor_groups = {fleshy=10},
-        damage_groups = {cracky=3, snappy=2, choppy=3, crumbly=2, level=1}
+		damage_groups = {cracky=3, snappy=2, choppy=3, crumbly=2, level=1}
     })
 *See ***armor.lua*** under **3d_armor>>3d_armor** for further examples*
 
@@ -363,13 +363,12 @@ Durability is determined by the value assigned to the group ***armor_use***. The
 ### Armor Material 
 The material the armor is made from is defined by adding the material to the end of registered armor item name. It is very important the material is the last item in the registered item name and it is preceeded by an "_" eg "_materialname".
 The material name is what 3d_armor uses to determine if a player is wearing a set of armor. To recieve the set bonus all items worn must be made of the same material.
-
 So to get a set bonus under the default set settings the players armor items listed below must be made of the same material:
-head - Helmet   
-torso - Chestplate   
-legs - Leggings   
-feet - Boots   
-shield - Shields   
+* head - Helmet
+* torso - Chestplate
+* legs - Leggings
+* feet - Boots
+* shield - Shields   
 
 If all of the above were made of material "wood" the player would recieve an ***armor_set_bonus*** of armor_level * 1.1, essentially +10%  
 

--- a/3d_armor/README.md
+++ b/3d_armor/README.md
@@ -382,7 +382,7 @@ If all of the above were made of material "wood" the player would recieve an ***
 		damage_groups = {cracky=3, snappy=2, choppy=2, crumbly=1, level=2},
 	})
 	
- **Example One** 
+ **Example Two** 
  
 	armor:register_armor("new_mod:helmet_spartan_bronze", {
 		description = S("Spartan Helmet"),

--- a/3d_armor/README.md
+++ b/3d_armor/README.md
@@ -384,7 +384,7 @@ If all of the above were made of material wood the player wood recieve a ***armo
  **Example One** 
  
 	armor:register_armor("new_mod:helmet_spartan_bronze", {
-		description = S("Bronze Helmet"),
+		description = S("Spartan Helmet"),
 		inventory_image = "new_mod_inv_helmet_spartan_bronze.png",
 		groups = {armor_head=1, armor_heal=6, armor_use=350, physics_speed=-0.01, physics_gravity=0.01},
 		armor_groups = {fleshy=12},

--- a/3d_armor/README.md
+++ b/3d_armor/README.md
@@ -1,28 +1,29 @@
 # [mod] Visible Player Armor [3d_armor]
- 
+
 |  |  |  |  | 
 |--|--|--|--|
-|-[Overview](#overview)                                                      |||-[API](#api)|
-|-[Armor Configuration](#armor-configuration)                                |||- - [3d_Armor Item Storage](#3d_armor-item-storage)
-|- - [disable_specific_materials](#to-disable-individual-armor-materials)    |||- - [Armor Registration](#armor-registration)
-|- - [armor_set_elements](#allows-the-customisation-of-armor-set)            |||- - [Registering Armor Groups](#registering-armor-groups)
-|- - [armor_set_bonus](#armor-set-bonus-multiplier )                         |||- - [Groups used by 3d_Armor](#groups-used-by-3d_armor)
-|- - [armor_init_delay](#initialization-glitches-when-a-player-first-joins)  |||- - - [Elements](#elements)
-|- - [armor_init_times](#number-of-initialization-attempts)                  |||- - - [Attributes](#attributes)
-|- - [armor_bones_delay](#armor-not-in-bones-due-to-server-lag)              |||- - - [Physics](#physics)
-|- - [armor_update_time](#how-often-player-armor-items-are-updated)          |||- - - [Durability](#durability)
-|- - [armor_drop](#drop-armor-when-a-player-dies)                            |||- - - [Armor Material](#armor-material)
-|- - [armor_destroy](#destroy-armor-when-a-player-dies)                      |||- - [Armour Functions](#armor-functions)
-|- - [armor_level_multiplier](#armor-level-multiplyer)                       |||- - - [armor:set_player_armor](#armor-set_player_armor)
-|- - [armor_heal_multiplier](#armor-healing-multiplyer)                      |||- - - [armor:punch](#armor-punch)
-|- - [armor_water_protect](#enable-water-protection)                         |||- - - [armor:damage](#armor-damage)
-|- - [armor_fire_protect](#enable-fire-protection)                           |||- - - [armor:remove_all](#armor-remove_all)
-|- - [armor_punch_damage](#enable-punch-damage-effects)                      |||- - - [armor:equip](#armor-equip)
-|- - [armor_migrate_old_inventory](#migration-of-old-armor-inventories)      |||- - - [armor:unequip](#armor-unequip)
-|- - [wieldview_update_time](#how-often-player-wield-items-are-updated)      |||- - - [armor:update_skin](#armor-update_skin)
-|-[Credits](#credits)                                                        |||- - [Callbacks](#Callbacks)
-|                                                                            |||- - - [Item callbacks](#item-callbacks)
-|                                                                            |||- - - [Global callbacks](#global-callbacks)
+|-[Overview](#overview)														|||-[API](#api)
+|-[Armor Configuration](#armor-configuration)								|||- - [3d_Armor Item Storage](#3d_armor-item-storage)
+|- - [disable_specific_materials](#to-disable-individual-armor-materials)	|||- - [Armor Registration](#armor-registration)
+|- - [armor_init_delay](#initialization-glitches-when-a-player-first-joins)	|||- - [Registering Armor Groups](#registering-armor-groups)
+|- - [armor_init_times](#number-of-initialization-attempts)					|||- - [Groups used by 3d_Armor](#groups-used-by-3d_armor)
+|- - [armor_bones_delay](#armor-not-in-bones-due-to-server-lag)				|||- - - [Elements](#elements)
+|- - [armor_update_time](#how-often-player-armor-items-are-updated)			|||- - - [Attributes](#attributes)
+|- - [armor_drop](#drop-armor-when-a-player-dies)							|||- - - [Physics](#physics)
+|- - [armor_destroy](#destroy-armor-when-a-player-dies)						|||- - - [Durability](#durability)
+|- - [armor_level_multiplier](#armor-level-multiplyer)						|||- - - [Armor Material](#armor-material)
+|- - [armor_heal_multiplier](#armor-healing-multiplyer)						|||- - [Armour Functions](#armor-functions)
+|- - [armor_set_elements](#allows-the-customisation-of-armor-set)			|||- - - [armor:set_player_armor](#armor-set_player_armor)
+|- - [armor_set_bonus](#armor-set-bonus-multiplier )						|||- - - [armor:punch](#armor-punch)
+|- - [armor_water_protect](#enable-water-protection)						|||- - - [armor:damage](#armor-damage)
+|- - [armor_fire_protect](#enable-fire-protection)							|||- - - [armor:remove_all](#armor-remove_all)
+|- - [armor_punch_damage](#enable-punch-damage-effects)						|||- - - [armor:equip](#armor-equip)
+|- - [armor_migrate_old_inventory](#migration-of-old-armor-inventories)		|||- - - [armor:unequip](#armor-unequip)
+|- - [wieldview_update_time](#how-often-player-wield-items-are-updated)		|||- - - [armor:update_skin](#armor-update_skin)
+|-[Credits](#credits)														|||- - [Callbacks](#Callbacks)
+|																			|||- - - [Item callbacks](#item-callbacks)
+|																			|||- - - [Global callbacks](#global-callbacks)
+
 # Overview
 
 **Depends:** default
@@ -39,7 +40,7 @@ Overall level is boosted by 10% when wearing a full matching set.
 
 # Armor Configuration
 
-Override the following default settings by adding them to your ***minetest.conf*** file.
+Change the following default settings by going to Main Menu>>Settings(Tab)>>All Settings(Button)>>Mods>>minetest-3d_Armor>>3d_Armor
 
 ### To disable individual armor materials
  **set the below to false**
@@ -52,16 +53,6 @@ Override the following default settings by adding them to your ***minetest.conf*
     armor_material_gold = true
     armor_material_mithril = true
     armor_material_crystal = true
-
-### Allows the customisation of armor set 
- **Shields already configured as part of the set - this is configured from [Elements](#elements) second half of the name eg armor_head is head**
- 
-    armor_set_elements = head torso legs feet shield
-
-### Armor set bonus multiplier 
- **Set to 1 to disable set bonus**
- 
-    armor_set_multiplier = 1.1
 
 ### Initialization glitches when a player first joins
  **Increase to prevent glitches**
@@ -104,6 +95,17 @@ Override the following default settings by adding them to your ***minetest.conf*
  **eg: armor_heal_multiplier = 0 will disable healing altogether.**
 
     armor_heal_multiplier = 1
+	
+### Allows the customisation of armor set 
+ **Shields already configured as need to be worn to complete an armor set**
+ **These names come from [Elements](#elements), the second half of the name eg armor_head is head**
+ 
+    armor_set_elements = head torso legs feet shield
+
+### Armor set bonus multiplier 
+ **Set to 1 to disable set bonus**
+ 
+    armor_set_multiplier = 1.1
 
 ### Enable water protection
  **periodically restores breath when activated**
@@ -360,7 +362,7 @@ Durability is determined by the value assigned to the group ***armor_use***. The
 
 ### Armor Material 
 The material the armor is made from is defined by adding the material to the end of registered armor item name. It is very important the material is the last item in the registered item name and it is preceeded by an "_" eg "_materialname".
-The material name is what 3d_armor uses to determine if a player is wearing a set of armor, all items worn that are configured as an item to be included in the set check must be made of the same material for the player to recieve a set armor bonus.
+The material name is what 3d_armor uses to determine if a player is wearing a set of armor. To recieve the set bonus all items worn must be made of the same material.
 
 So to get a set bonus under the default set settings the players armor items listed below must be made of the same material:
 head - Helmet   
@@ -369,7 +371,7 @@ legs - Leggings
 feet - Boots   
 shield - Shields   
 
-If all of the above were made of material wood the player wood recieve a ***armor_set_bonus*** of armor_level * 1.1, essentially +10%  
+If all of the above were made of material "wood" the player would recieve an ***armor_set_bonus*** of armor_level * 1.1, essentially +10%  
 
  **Example One** 
  
@@ -391,7 +393,7 @@ If all of the above were made of material wood the player wood recieve a ***armo
 		damage_groups = {cracky=3, snappy=2, choppy=2, crumbly=1, level=2},
 	})
 
-***Note: At the moment an armor can only be made of one material***
+***Note: At the moment an armor item can only be made of one material***
 
 ## Armor Functions
 

--- a/3d_armor/README.md
+++ b/3d_armor/README.md
@@ -98,7 +98,7 @@ Change the following default settings by going to Main Menu>>Settings(Tab)>>All 
 	
 ### Allows the customisation of armor set 
  **Shields already configured as need to be worn to complete an armor set**   
- **These names come from [Elements](#elements), the second half of the element name eg armor_head is head**
+ **These names come from [Groups used by 3d_Armor](#groups-used-by-3d_armor), the second half of the element name eg armor_head is head**
  
     armor_set_elements = head torso legs feet shield
 

--- a/3d_armor/README.md
+++ b/3d_armor/README.md
@@ -54,7 +54,7 @@ Override the following default settings by adding them to your ***minetest.conf*
     armor_material_crystal = true
 
 ### Allows the customisation of armor set 
- **Shields already configured as part of the set**
+ **Shields already configured as part of the set - this is configured from [Elements](#elements) second half of the name eg armor_head is head**
  
     armor_set_elements = head torso legs feet shield
 

--- a/3d_armor/README.md
+++ b/3d_armor/README.md
@@ -264,13 +264,9 @@ Adding Elements is more complex but the below code can be used to add new elemen
 
     if minetest.global_exists("armor") and armor.elements then
     	table.insert(armor.elements, "hands")
-    	local mult = armor.config.level_multiplier or 1
-    	armor.config.level_multiplier = mult * 0.5
     end
 **1st line** not strictly needed but checks that the global table "armor" and subtable "elements" exists   
-**2nd line** adds a new value to the armor.elements table called "hands"   
-**3rd line** in this case will be set to one ***note: need more detail here***    
-**4th line** simply sets the multiplier, by setting 0.5 smaller armor becomes less effective and larger more effective. good values are between 0.1 and 1 in increments of 0.1.   
+**2nd line** adds a new value to the armor.elements table called "hands"  
 
 See ***init.lua*** under **3d_armor>>shields** for a further example
 

--- a/3d_armor/README.md
+++ b/3d_armor/README.md
@@ -359,7 +359,7 @@ Durability is determined by the value assigned to the group ***armor_use***. The
  After 327 uses(hits) the armor item will break. 
 
 ### Armor Material 
-The material the armor is made from is defined by adding the material to the end of register armor item name. It is very important the material is the last item in the registered item name and it is preceeded by an "_", "_materialname".
+The material the armor is made from is defined by adding the material to the end of registered armor item name. It is very important the material is the last item in the registered item name and it is preceeded by an "_" eg "_materialname".
 The material name is what 3d_armor uses to determine if a player is wearing a set of armor, all items worn that are configured as an item to be included in the set check must be made of the same material for the player to recieve a set armor bonus.
 
 So to get a set bonus under the default set settings the players armor items listed below must be made of the same material:
@@ -369,7 +369,7 @@ legs - Leggings
 feet - Boots   
 shield - Shields   
 
-If all of the above were made of material wood the player wood recieve a ***armor_set_bonus*** of armor_level * 1.1   
+If all of the above were made of material wood the player wood recieve a ***armor_set_bonus*** of armor_level * 1.1, essentially +10%  
 
  **Example One** 
  

--- a/3d_armor/README.md
+++ b/3d_armor/README.md
@@ -97,8 +97,8 @@ Change the following default settings by going to Main Menu>>Settings(Tab)>>All 
     armor_heal_multiplier = 1
 	
 ### Allows the customisation of armor set 
- **Shields already configured as need to be worn to complete an armor set**
- **These names come from [Elements](#elements), the second half of the name eg armor_head is head**
+ **Shields already configured as need to be worn to complete an armor set**   
+ **These names come from [Elements](#elements), the second half of the element name eg armor_head is head**
  
     armor_set_elements = head torso legs feet shield
 

--- a/3d_armor/README.md
+++ b/3d_armor/README.md
@@ -186,7 +186,7 @@ Wrapper function for `minetest.register_tool`, which enables the easy registrati
     	preview = "mod_name_leather_chestplate_preview.png",
     	groups = {armor_torso=1, armor_heal=0, armor_use=2000, flammable=1},
     	armor_groups = {fleshy=10},
-		damage_groups = {cracky=3, snappy=2, choppy=3, crumbly=2, level=1}
+    	damage_groups = {cracky=3, snappy=2, choppy=3, crumbly=2, level=1}
     })
 *See ***armor.lua*** under **3d_armor>>3d_armor** for further examples*
 

--- a/3d_armor/api.lua
+++ b/3d_armor/api.lua
@@ -124,8 +124,8 @@ armor.register_armor = function(self, name, def)
 	-- at the end of the item name and logging an error to debug if not.
 	local check_mat_exists = string.match(name, "%:.+_(.+)$")
 	if check_mat_exists == nil then
-		minetest.debug("WARNING:3d_armor - Registered Armor "..name..
-		" dosen't have \"_material\" specified at the end of the item registration name")
+		minetest.log("warning:[3d_armor] Registered armor "..name..
+		" does not have \"_material\" specified at the end of the item registration name")
 	end
 	minetest.register_tool(name, def)
 end
@@ -276,26 +276,24 @@ armor.set_player_armor = function(self, player)
 	-- of which armor pieces are needed to be worn to meet set bonus requirements
 	for loc,item in pairs(worn_armor) do
 		local item_mat = string.match(item, "%:.+_(.+)$")
-		for k,set_loc in pairs(armor.config.set_elements)do
+		local worn_key = item_mat or "unknown"
+		
+		for k,set_loc in pairs(armor.config.set_elements)do		
 			if set_loc == loc then
-				if item_mat ~= nil then
-					if set_worn[item_mat] == nil then
-						set_worn[item_mat] = 0
-						set_worn[item_mat] = set_worn[item_mat] + 1
-					else
-						set_worn[item_mat] = set_worn[item_mat] + 1
-					end
+				if set_worn[worn_key] == nil then
+					set_worn[worn_key] = 0
+					set_worn[worn_key] = set_worn[worn_key] + 1
 				else
-					if set_worn["unknown"] == nil then
-						set_worn["unknown"] = 0
-						set_worn["unknown"] = set_worn["unknown"] + 1
-					else
-						set_worn["unknown"] = set_worn["unknown"] + 1
-					end
+					set_worn[worn_key] = set_worn[worn_key] + 1
 				end
 			end
 		end
 	end
+	-- The following code checks if the player should recieve the set bonus/multiplyer
+	-- by testing the table length of armor.config.set_elements (numeric key) and 
+	-- player armor pieces worn (arm_piece_num) against each other if numbers 
+	-- are equal the player is wearing a full set of armor. We don't need to 
+	-- check locations here as that was performed at api.lua line 282 "set_loc == loc".
 	for mat_name,arm_piece_num in pairs(set_worn) do
 		if arm_piece_num == #armor.config.set_elements then
 			armor_multi = armor.config.set_multiplier

--- a/3d_armor/api.lua
+++ b/3d_armor/api.lua
@@ -124,7 +124,8 @@ armor.register_armor = function(self, name, def)
 	-- at the end of the item name and logging an error to debug if not.
 	local check_mat_exists = string.match(name, "%:.+_(.+)$")
 	if check_mat_exists == nil then
-		minetest.debug("WARNING:3d_armor - Registered Armor "..name.." dosen't have \"_material\" specified at the end of the item registration name")
+		minetest.debug("WARNING:3d_armor - Registered Armor "..name..
+		" dosen't have \"_material\" specified at the end of the item registration name")
 	end
 	minetest.register_tool(name, def)
 end
@@ -293,8 +294,8 @@ armor.set_player_armor = function(self, player)
 					end
 				end
 			end
-		end		
-	end	
+		end
+	end
 	for mat_name,arm_piece_num in pairs(set_worn) do
 		if arm_piece_num == #armor.config.set_elements then
 			armor_multi = armor.config.set_multiplier

--- a/3d_armor/api.lua
+++ b/3d_armor/api.lua
@@ -119,6 +119,13 @@ armor.register_armor = function(self, name, def)
 		end
 		return armor:equip(player, itemstack)
 	end
+	-- The below is a very basic check to try and see if a material name exists as part
+	-- of the item name. However this check is very simple and just checks theres "_something"
+	-- at the end of the item name and logging an error to debug if not.
+	local check_mat_exists = string.match(name, "%:.+_(.+)$")
+	if check_mat_exists == nil then
+		minetest.debug("WARNING:3d_armor - Registered Armor "..name.." dosen't have \"_material\" specified at the end of the item registration name")
+	end	
 	minetest.register_tool(name, def)
 end
 
@@ -281,7 +288,6 @@ armor.set_player_armor = function(self, player)
 						set_worn[item_mat] = set_worn[item_mat] + 1
 					end
 				else
-					minetest.debug("WARNING:3d_armor - Registered Armor "..item.." dosen't have _\"material\" specified at the end of the item registeration name")
 					if set_worn["unknown"] == nil then
 						set_worn["unknown"] = 0
 						set_worn["unknown"] = set_worn["unknown"] + 1

--- a/3d_armor/api.lua
+++ b/3d_armor/api.lua
@@ -207,6 +207,11 @@ armor.set_player_armor = function(self, player)
 	local levels = {}
 	local groups = {}
 	local change = {}
+	local set_worn = {}
+	local armor_multi = 0
+	local worn_armor = armor:get_weared_armor_elements(player)
+	local use_legacy_calc = 0
+	local set_bonus_name
 	for _, phys in pairs(self.physics) do
 		physics[phys] = 1
 	end
@@ -261,13 +266,9 @@ armor.set_player_armor = function(self, player)
 				attributes[attr] = attributes[attr] + value
 			end
 		end
-	end
--- New (Dec 2020) for working out armor_set and multiplier	
-	local set_worn = {}
-	local armor_multi = 0
-	local worn_armor = armor:get_weared_armor_elements(player)
-	local use_legacy_calc = 0
-	local set_bonus_name
+	end	
+	-- The following code compares player worn armor items against requirements
+	-- of which armor pieces are needed to be worn to meet set bonus requirements	
 	for loc,item in pairs(worn_armor) do
 		local item_mat = string.match(item, "%:.+_(.+)$")
 		for k,set_loc in pairs(armor.config.set_elements)do
@@ -297,7 +298,7 @@ armor.set_player_armor = function(self, player)
 			set_bonus_name = mat_name
 		end
 	end	
--- End New (Dec 2020)
+	
 	for group, level in pairs(levels) do
 		if level > 0 then
 			level = level * armor.config.level_multiplier

--- a/3d_armor/api.lua
+++ b/3d_armor/api.lua
@@ -278,6 +278,7 @@ armor.set_player_armor = function(self, player)
 		local item_mat = string.match(item, "%:.+_(.+)$")
 		local worn_key = item_mat or "unknown"
 
+		-- Perform location checks to ensure the armor is worn correctly
 		for k,set_loc in pairs(armor.config.set_elements)do
 			if set_loc == loc then
 				if set_worn[worn_key] == nil then
@@ -289,11 +290,8 @@ armor.set_player_armor = function(self, player)
 			end
 		end
 	end
-	-- The following code checks if the player should recieve the set bonus/multiplyer
-	-- by testing the table length of armor.config.set_elements (numeric key) and
-	-- player armor pieces worn (arm_piece_num) against each other if numbers
-	-- are equal the player is wearing a full set of armor. We don't need to
-	-- check locations here as that was performed at api.lua line 282 "set_loc == loc".
+
+	-- Apply the armor multiplier only if the player is wearing a full set of armor
 	for mat_name,arm_piece_num in pairs(set_worn) do
 		if arm_piece_num == #armor.config.set_elements then
 			armor_multi = armor.config.set_multiplier

--- a/3d_armor/api.lua
+++ b/3d_armor/api.lua
@@ -277,8 +277,8 @@ armor.set_player_armor = function(self, player)
 	for loc,item in pairs(worn_armor) do
 		local item_mat = string.match(item, "%:.+_(.+)$")
 		local worn_key = item_mat or "unknown"
-		
-		for k,set_loc in pairs(armor.config.set_elements)do		
+
+		for k,set_loc in pairs(armor.config.set_elements)do
 			if set_loc == loc then
 				if set_worn[worn_key] == nil then
 					set_worn[worn_key] = 0
@@ -290,9 +290,9 @@ armor.set_player_armor = function(self, player)
 		end
 	end
 	-- The following code checks if the player should recieve the set bonus/multiplyer
-	-- by testing the table length of armor.config.set_elements (numeric key) and 
-	-- player armor pieces worn (arm_piece_num) against each other if numbers 
-	-- are equal the player is wearing a full set of armor. We don't need to 
+	-- by testing the table length of armor.config.set_elements (numeric key) and
+	-- player armor pieces worn (arm_piece_num) against each other if numbers
+	-- are equal the player is wearing a full set of armor. We don't need to
 	-- check locations here as that was performed at api.lua line 282 "set_loc == loc".
 	for mat_name,arm_piece_num in pairs(set_worn) do
 		if arm_piece_num == #armor.config.set_elements then

--- a/3d_armor/api.lua
+++ b/3d_armor/api.lua
@@ -96,7 +96,7 @@ armor.config = {
 	material_mithril = true,
 	material_crystal = true,
 	set_elements = "head torso legs feet shield",
-	set_multiplier = 1.1,	
+	set_multiplier = 1.1,
 	water_protect = true,
 	fire_protect = minetest.get_modpath("ethereal") ~= nil,
 	fire_protect_torch = minetest.get_modpath("ethereal") ~= nil,
@@ -125,7 +125,7 @@ armor.register_armor = function(self, name, def)
 	local check_mat_exists = string.match(name, "%:.+_(.+)$")
 	if check_mat_exists == nil then
 		minetest.debug("WARNING:3d_armor - Registered Armor "..name.." dosen't have \"_material\" specified at the end of the item registration name")
-	end	
+	end
 	minetest.register_tool(name, def)
 end
 
@@ -206,7 +206,6 @@ armor.set_player_armor = function(self, player)
 	end
 	local state = 0
 	local count = 0
-	local material = {count=1}
 	local preview = armor:get_preview(name)
 	local texture = "3d_armor_trans.png"
 	local physics = {}
@@ -217,8 +216,6 @@ armor.set_player_armor = function(self, player)
 	local set_worn = {}
 	local armor_multi = 0
 	local worn_armor = armor:get_weared_armor_elements(player)
-	local use_legacy_calc = 0
-	local set_bonus_name
 	for _, phys in pairs(self.physics) do
 		physics[phys] = 1
 	end
@@ -273,14 +270,14 @@ armor.set_player_armor = function(self, player)
 				attributes[attr] = attributes[attr] + value
 			end
 		end
-	end	
+	end
 	-- The following code compares player worn armor items against requirements
-	-- of which armor pieces are needed to be worn to meet set bonus requirements	
+	-- of which armor pieces are needed to be worn to meet set bonus requirements
 	for loc,item in pairs(worn_armor) do
 		local item_mat = string.match(item, "%:.+_(.+)$")
 		for k,set_loc in pairs(armor.config.set_elements)do
 			if set_loc == loc then
-				if item_mat ~= nil then				
+				if item_mat ~= nil then
 					if set_worn[item_mat] == nil then
 						set_worn[item_mat] = 0
 						set_worn[item_mat] = set_worn[item_mat] + 1
@@ -293,18 +290,16 @@ armor.set_player_armor = function(self, player)
 						set_worn["unknown"] = set_worn["unknown"] + 1
 					else
 						set_worn["unknown"] = set_worn["unknown"] + 1
-					end					
+					end
 				end
 			end
 		end		
 	end	
 	for mat_name,arm_piece_num in pairs(set_worn) do
-		if arm_piece_num == #armor.config.set_elements then 
+		if arm_piece_num == #armor.config.set_elements then
 			armor_multi = armor.config.set_multiplier
-			set_bonus_name = mat_name
 		end
-	end	
-	
+	end
 	for group, level in pairs(levels) do
 		if level > 0 then
 			level = level * armor.config.level_multiplier

--- a/3d_armor/init.lua
+++ b/3d_armor/init.lua
@@ -48,6 +48,8 @@ for name, config in pairs(armor.config) do
 	local setting = minetest.settings:get("armor_"..name)
 	if type(config) == "number" then
 		setting = tonumber(setting)
+	elseif type(config) == "string" then
+		setting = tostring(setting)
 	elseif type(config) == "boolean" then
 		setting = minetest.settings:get_bool("armor_"..name)
 	end
@@ -60,6 +62,13 @@ for material, _ in pairs(armor.materials) do
 	if armor.config[key] == false then
 		armor.materials[material] = nil
 	end
+end
+
+-- Convert set_elements to a Lua table splitting on blank spaces
+local t_set_elements = armor.config.set_elements
+armor.config.set_elements = {}
+for element in string.gmatch(t_set_elements, "[^%s]+") do
+   table.insert(armor.config.set_elements,element)
 end
 
 -- Remove torch damage if fire_protect_torch == false

--- a/3d_armor/init.lua
+++ b/3d_armor/init.lua
@@ -116,7 +116,6 @@ dofile(modpath.."/armor.lua")
 armor.formspec = armor.formspec..
 	"label[5,1;"..F(S("Level"))..": armor_level]"..
 	"label[5,1.5;"..F(S("Heal"))..": armor_attr_heal]"
-	"label[2,5;"..F(S("Set Bonus"))..": armor_attr_heal]"
 if armor.config.fire_protect then
 	armor.formspec = armor.formspec.."label[5,2;"..F(S("Fire"))..": armor_attr_fire]"
 end

--- a/3d_armor/init.lua
+++ b/3d_armor/init.lua
@@ -116,6 +116,7 @@ dofile(modpath.."/armor.lua")
 armor.formspec = armor.formspec..
 	"label[5,1;"..F(S("Level"))..": armor_level]"..
 	"label[5,1.5;"..F(S("Heal"))..": armor_attr_heal]"
+	"label[2,5;"..F(S("Set Bonus"))..": armor_attr_heal]"
 if armor.config.fire_protect then
 	armor.formspec = armor.formspec.."label[5,2;"..F(S("Fire"))..": armor_attr_fire]"
 end

--- a/3d_armor/init.lua
+++ b/3d_armor/init.lua
@@ -66,7 +66,6 @@ end
 
 -- Convert set_elements to a Lua table splitting on blank spaces
 local t_set_elements = armor.config.set_elements
-armor.config.set_elements = {}
 armor.config.set_elements = string.split(t_set_elements, " ")
 
 -- Remove torch damage if fire_protect_torch == false

--- a/3d_armor/init.lua
+++ b/3d_armor/init.lua
@@ -67,9 +67,7 @@ end
 -- Convert set_elements to a Lua table splitting on blank spaces
 local t_set_elements = armor.config.set_elements
 armor.config.set_elements = {}
-for element in string.gmatch(t_set_elements, "[^%s]+") do
-   table.insert(armor.config.set_elements,element)
-end
+armor.config.set_elements = string.split(t_set_elements, " ")
 
 -- Remove torch damage if fire_protect_torch == false
 if armor.config.fire_protect_torch == false and armor.config.fire_protect == true then

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,4 +1,3 @@
-
 [3d_armor]
 
 armor_material_wood (Enable wood armor) bool true
@@ -9,6 +8,12 @@ armor_material_diamond (Enable diamond armor) bool true
 armor_material_gold (Enable gold armor) bool true
 armor_material_mithril (Enable mithril armor) bool true
 armor_material_crystal (Enable crystal armor) bool true
+
+# Armor set item names, remove or add items to include them or remove them from whats considered an Armor set.
+armor_set_elements (Armor set items) string head torso legs feet shield
+
+# Bonus multiplier when wearing armor set, set to the same as armor_level_multiplier to disable
+armor_set_multiplier (Armor Set Bonus multiplier) float 1.1
 
 # Increase this if you get initialization glitches when a player first joins.
 armor_init_delay (Initialization delay) int 2

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -9,12 +9,6 @@ armor_material_gold (Enable gold armor) bool true
 armor_material_mithril (Enable mithril armor) bool true
 armor_material_crystal (Enable crystal armor) bool true
 
-# Armor set item names, remove or add items to include them or remove them from whats considered an Armor set.
-armor_set_elements (Armor set items) string head torso legs feet shield
-
-# Bonus multiplier when wearing armor set, set to the same as armor_level_multiplier to disable
-armor_set_multiplier (Armor Set Bonus multiplier) float 1.1
-
 # Increase this if you get initialization glitches when a player first joins.
 armor_init_delay (Initialization delay) int 2
 
@@ -42,6 +36,12 @@ armor_level_multiplier (Armor effectiveness multiplier) float 1
 # You can use this to increase or decrease overall armor healing,
 # eg: armor_heal_multiplier = 0 will disable healing altogether.
 armor_heal_multiplier (Armor healing multiplier) float 1
+
+# Armor set item names, remove or add items to include them or remove them from whats considered an Armor set.
+armor_set_elements (Armor set items) string head torso legs feet shield
+
+# Bonus multiplier when wearing armor set, set to the same as armor_level_multiplier to disable
+armor_set_multiplier (Armor Set Bonus multiplier) float 1.1
 
 # Enable water protection (periodically restores breath when activated).
 armor_water_protect (Enable water protection) bool true


### PR DESCRIPTION
**Change Summary**
- Add settingtypes of:
  -  armor_set_elements
  - armor_set_multiplier
- Add check to armor.registration_armor for "_materialname", print msg to debug if not found
- Complete change to how an armor set is calculated
- Set elements linked to settingtypes no longer hard linked to num armor.elements
- Set multiplier linked to settingtypes no longer hard coded
- Readme.MD updated:
  - Addition of the 2 new settingtypes
  - Addition of "Armor Material" topic 
 
Testing and outcomes recorded in #35 all passed as expected