### PR TITLE
update fire and water protection

### DIFF
--- a/3d_armor/init.lua
+++ b/3d_armor/init.lua
@@ -482,7 +482,6 @@ if armor.config.fire_protect == true then
 		if reason.type == "node_damage" and reason.node then
 			-- fire protection
 			if armor.config.fire_protect == true and hp_change < 0 then
-				local hp = player:get_hp()
 				local name = player:get_player_name()
 				for _,igniter in pairs(armor.fire_nodes) do
 					if reason.node == igniter[1] then

--- a/3d_armor/init.lua
+++ b/3d_armor/init.lua
@@ -453,11 +453,11 @@ minetest.register_globalstep(function(dtime)
 		end
 	end
 
-	-- water breathing protection
+	-- water breathing protection, added by TenPlus1
 	if armor.config.water_protect == true then
 		for _,player in pairs(minetest.get_connected_players()) do
 			local name = player:get_player_name()
-			if name and armor.def[name].water > 0 and
+			if armor.def[name].water > 0 and
 					player:get_breath() < 10 then
 				player:set_breath(10)
 			end
@@ -465,8 +465,7 @@ minetest.register_globalstep(function(dtime)
 	end
 end)
 
--- Fire Protection and water breathing, added by TenPlus1.
-
+-- Fire Protection, added by TenPlus1.
 if armor.config.fire_protect == true then
 	-- override any hot nodes that do not already deal damage
 	for _, row in pairs(armor.fire_nodes) do

--- a/3d_armor/init.lua
+++ b/3d_armor/init.lua
@@ -477,34 +477,24 @@ else
 end
 
 if armor.config.fire_protect == true then
+	minetest.register_on_player_hpchange(function(player, hp_change, reason)
 
-minetest.register_on_player_hpchange(function(player, hp_change, reason)
-
-	if reason.type == "node_damage" and reason.node then
-
-		-- fire protection
-		if armor.config.fire_protect == true and hp_change < 0 then
-
-			local hp = player:get_hp()
-			local name = player:get_player_name()
-
-			for _,igniter in pairs(armor.fire_nodes) do
-
-				if reason.node == igniter[1] then
-
-					if armor.def[name].fire < igniter[2] then
-
-						armor:punch(player, "fire")
-
-					else
-
-						hp_change = 0
+		if reason.type == "node_damage" and reason.node then
+			-- fire protection
+			if armor.config.fire_protect == true and hp_change < 0 then
+				local hp = player:get_hp()
+				local name = player:get_player_name()
+				for _,igniter in pairs(armor.fire_nodes) do
+					if reason.node == igniter[1] then
+						if armor.def[name].fire < igniter[2] then
+							armor:punch(player, "fire")
+						else
+							hp_change = 0
+						end
 					end
 				end
 			end
 		end
-	end
-
-	return hp_change
-
-end, true)
+		return hp_change
+	end, true)
+end

--- a/3d_armor/init.lua
+++ b/3d_armor/init.lua
@@ -468,12 +468,17 @@ end)
 -- Fire Protection and water breathing, added by TenPlus1.
 
 if armor.config.fire_protect == true then
-	-- override torch damage
-	minetest.override_item("default:torch", {damage_per_second = 1})
-	minetest.override_item("default:torch_ceiling", {damage_per_second = 1})
-	minetest.override_item("default:torch_wall", {damage_per_second = 1})
+	-- override any hot nodes that do not already deal damage
+	for _, row in pairs(armor.fire_nodes) do
+		if minetest.registered_nodes[row[1]] then
+			local damage = minetest.registered_nodes[row[1]].damage_per_second
+			if not damage or damage == 0 then
+				minetest.override_item(row[1], {damage_per_second = row[3]})
+			end
+		end
+	end
 else
-	print (S("[3d_armor] Fire Nodes disabled"))
+	print ("[3d_armor] Fire Nodes disabled")
 end
 
 if armor.config.fire_protect == true then

--- a/3d_armor/init.lua
+++ b/3d_armor/init.lua
@@ -436,80 +436,75 @@ end, true)
 
 minetest.register_globalstep(function(dtime)
 	timer = timer + dtime
-	if timer > armor.config.init_delay then
-		for player, count in pairs(pending_players) do
-			local remove = init_player_armor(player) == true
-			pending_players[player] = count + 1
-			if remove == false and count > armor.config.init_times then
-				minetest.log("warning", S("3d_armor: Failed to initialize player"))
-				remove = true
-			end
-			if remove == true then
-				pending_players[player] = nil
+	if timer <= armor.config.init_delay then
+		return
+	end
+	timer = 0
+
+	for player, count in pairs(pending_players) do
+		local remove = init_player_armor(player) == true
+		pending_players[player] = count + 1
+		if remove == false and count > armor.config.init_times then
+			minetest.log("warning", S("3d_armor: Failed to initialize player"))
+			remove = true
+		end
+		if remove == true then
+			pending_players[player] = nil
+		end
+	end
+
+	-- water breathing protection
+	if armor.config.water_protect == true then
+		for _,player in pairs(minetest.get_connected_players()) do
+			local name = player:get_player_name()
+			if name and armor.def[name].water > 0 and
+					player:get_breath() < 10 then
+				player:set_breath(10)
 			end
 		end
-		timer = 0
 	end
 end)
 
 -- Fire Protection and water breathing, added by TenPlus1.
 
 if armor.config.fire_protect == true then
-	-- override hot nodes so they do not hurt player anywhere but mod
-	for _, row in pairs(armor.fire_nodes) do
-		if minetest.registered_nodes[row[1]] then
-			minetest.override_item(row[1], {damage_per_second = 0})
-		end
-	end
+	-- override torch damage
+	minetest.override_item("default:torch", {damage_per_second = 1})
+	minetest.override_item("default:torch_ceiling", {damage_per_second = 1})
+	minetest.override_item("default:torch_wall", {damage_per_second = 1})
 else
 	print (S("[3d_armor] Fire Nodes disabled"))
 end
 
-if armor.config.water_protect == true or armor.config.fire_protect == true then
-	minetest.register_globalstep(function(dtime)
-		armor.timer = armor.timer + dtime
-		if armor.timer < armor.config.update_time then
-			return
-		end
-		for _,player in pairs(minetest.get_connected_players()) do
-			local name = player:get_player_name()
-			local pos = player:get_pos()
+if armor.config.fire_protect == true then
+
+minetest.register_on_player_hpchange(function(player, hp_change, reason)
+
+	if reason.type == "node_damage" and reason.node then
+
+		-- fire protection
+		if armor.config.fire_protect == true and hp_change < 0 then
+
 			local hp = player:get_hp()
-			if not name or not pos or not hp then
-				return
-			end
-			-- water breathing
-			if armor.config.water_protect == true then
-				if armor.def[name].water > 0 and
-						player:get_breath() < 10 then
-					player:set_breath(10)
-				end
-			end
-			-- fire protection
-			if armor.config.fire_protect == true then
-				local fire_damage = true
-				pos.y = pos.y + 1.4 -- head level
-				local node_head = minetest.get_node(pos).name
-				pos.y = pos.y - 1.2 -- feet level
-				local node_feet = minetest.get_node(pos).name
-				-- is player inside a hot node?
-				for _, row in pairs(armor.fire_nodes) do
-					-- check fire protection, if not enough then get hurt
-					if row[1] == node_head or row[1] == node_feet then
-						if fire_damage == true then
-							armor:punch(player, "fire")
-							last_punch_time[name] = minetest.get_gametime()
-							fire_damage = false
-						end
-						if hp > 0 and armor.def[name].fire < row[2] then
-							hp = hp - row[3] * armor.config.update_time
-							player:set_hp(hp)
-							break
-						end
+			local name = player:get_player_name()
+
+			for _,igniter in pairs(armor.fire_nodes) do
+
+				if reason.node == igniter[1] then
+
+					if armor.def[name].fire < igniter[2] then
+
+						armor:punch(player, "fire")
+
+					else
+
+						hp_change = 0
 					end
 				end
 			end
 		end
-		armor.timer = 0
-	end)
-end
+	end
+
+	return hp_change
+
+end, true)


### PR DESCRIPTION
Update fire protection to use register_on_player_hpchange instead of overriding node damage, move water protection into different globalstep.