### PR TITLE
Add setting to disable armor visuals on player model

### DIFF
--- a/3d_armor/api.lua
+++ b/3d_armor/api.lua
@@ -202,7 +202,7 @@ end
 
 
 -- armor is not visible on player model if enabled
-local transparent_armor = core.settings:get_bool("armor_transparent", false)
+local transparent_armor = minetest.settings:get_bool("armor_transparent", false)
 
 armor.set_player_armor = function(self, player)
 	local name, armor_inv = self:get_valid_player(player, "[set_player_armor]")

--- a/3d_armor/api.lua
+++ b/3d_armor/api.lua
@@ -200,6 +200,10 @@ armor.update_player_visuals = function(self, player)
 	self:run_callbacks("on_update", player)
 end
 
+
+-- armor is not visible on player model if enabled
+local transparent_armor = core.settings:get_bool("armor_transparent", false)
+
 armor.set_player_armor = function(self, player)
 	local name, armor_inv = self:get_valid_player(player, "[set_player_armor]")
 	if not name then
@@ -258,7 +262,9 @@ armor.set_player_armor = function(self, player)
 			tex = tex:gsub(".png$", "")
 			local prev = def.preview or tex.."_preview"
 			prev = prev:gsub(".png$", "")
-			texture = texture.."^"..tex..".png"
+			if not transparent_armor then
+				texture = texture.."^"..tex..".png"
+			end
 			preview = preview.."^"..prev..".png"
 			state = state + stack:get_wear()
 			count = count + 1

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -58,6 +58,9 @@ armor_punch_damage (Enable damage effects) bool true
 # Enable migration of old armor inventories.
 armor_migrate_old_inventory (Migrate old armor inventories) bool true
 
+# Don't show armor on character model.
+armor_transparent (Transparent armor) bool false
+
 
 [shields]
 


### PR DESCRIPTION
Adds boolean setting `armor_transparent`:
- `true`: disables armor visuals on player model
- `false`: normal behavior
- defalt: `false`

Closes: #46