### PR TITLE
Allow skin_mod Value to be Set Manually

### DIFF
--- a/3d_armor/api.lua
+++ b/3d_armor/api.lua
@@ -671,3 +671,10 @@ armor.drop_armor = function(pos, stack)
 		end
 	end
 end
+
+--- Allows skin mod to be set manually.
+--
+--  Useful for skin mod forks that do not use the same name.
+armor.set_skin_mod = function(mod)
+	armor.skin_mod = mod
+end


### PR DESCRIPTION
This adds global method `armor.set_skin_mod` so that `armor.skin_mod` value can be set manually. Useful for skin mod forks that do not use the same name.

I discovered that when I forked the [wardrobe](https://github.com/prestidigitator/minetest-mod-wardrobe) mod & renamed it, it was no longer compatible with 3d_armor. This fixes that by allowing me to set `armor.skin_mod` value to "wardrobe".