### PR TITLE
Reduce skin_mod Visibility

### DIFF
--- a/3d_armor/api.lua
+++ b/3d_armor/api.lua
@@ -529,12 +529,14 @@ armor.remove_all = function(self, player)
 	self:save_armor_inventory(player)
 end
 
+local skin_mod
+
 armor.get_player_skin = function(self, name)
-	if (self.skin_mod == "skins" or self.skin_mod == "simple_skins") and skins.skins[name] then
+	if (skin_mod == "skins" or skin_mod == "simple_skins") and skins.skins[name] then
 		return skins.skins[name]..".png"
-	elseif self.skin_mod == "u_skins" and u_skins.u_skins[name] then
+	elseif skin_mod == "u_skins" and u_skins.u_skins[name] then
 		return u_skins.u_skins[name]..".png"
-	elseif self.skin_mod == "wardrobe" and wardrobe.playerSkins and wardrobe.playerSkins[name] then
+	elseif skin_mod == "wardrobe" and wardrobe.playerSkins and wardrobe.playerSkins[name] then
 		return wardrobe.playerSkins[name]
 	end
 	return armor.default_skin..".png"
@@ -678,5 +680,5 @@ end
 --
 --  Useful for skin mod forks that do not use the same name.
 armor.set_skin_mod = function(mod)
-	armor.skin_mod = mod
+	skin_mod = mod
 end

--- a/3d_armor/init.lua
+++ b/3d_armor/init.lua
@@ -96,7 +96,7 @@ for _, mod in pairs(skin_mods) do
 				armor:add_preview(fn)
 			end
 		end
-		armor.skin_mod = mod
+		armor.set_skin_mod(mod)
 	end
 end
 if not minetest.get_modpath("moreores") then


### PR DESCRIPTION
Stores `skin_mod` in local variable so that it can only be modified via the `armor.set_skin_mod` method.