### PR TITLE
Exclude Some Files from Archives & Releases

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+.* export-ignore
+gendoc.sh export-ignore
+integration-test.sh export-ignore
+preview_gen.py export-ignore
+screenshot.xcf export-ignore


### PR DESCRIPTION
The following files & directories will not be added to archives & releases:
- files & directories starting with "."
- gendoc.sh
- integration-test.sh
- preview_gen.py
- screenshot.xcf