### PR TITLE
LDoc: Link to Favicon

### DIFF
--- a/.ldoc/config.ld
+++ b/.ldoc/config.ld
@@ -21,6 +21,7 @@ not_luadoc = true
 boilerplate = false
 wrap = false
 style = true
+favicon = "https://www.minetest.net/media/icon.svg"
 
 file = {
 	"3d_armor/api.lua",


### PR DESCRIPTION
Simply adds a favicon to each page linking to https://www.minetest.net/media/icon.svg.

<img src="https://www.minetest.net/media/icon.svg" width="16" height="16" />

[Live preview](https://antummt.github.io/mp-3d_armor/reference/).