### PR TITLE
remove pointless dependency on bakedclay

### DIFF
--- a/3d_armor/mod.conf
+++ b/3d_armor/mod.conf
@@ -1,4 +1,4 @@
 name = 3d_armor
 depends = default, player_api
-optional_depends = player_monoids, armor_monoid, pova, fire, ethereal, bakedclay, moreores, nether
+optional_depends = player_monoids, armor_monoid, pova, fire, ethereal, moreores, nether
 description = Adds craftable armor that is visible to other players.


### PR DESCRIPTION
so far as i can tell, bakedclay isn't used by 3d_armor or any of the other mods in the pack.

this will partially fix #89

i'm not entirely certain why the *api* part of the modpack also depends on content mods (default, nether, moreores, ethereal, fire). i can try to excise those as well, but it seems like there's at least references to them (e.g. as materials). 