### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-Modpack - 3d Armor [0.4.13]
-===========================
+Modpack - 3d Armor
+==================
 ![3d_armor screenshot](https://github.com/minetest-mods/3d_armor/blob/master/screenshot.png)
 
 
@@ -22,7 +22,7 @@ Modpack - 3d Armor [0.4.13]
 [mod] Visible Player Armor [3d_armor]
 -------------------------------------
 
-Minetest Version: 5.0.0
+Minetest Version: 5.0.0 and newer
 
 Game: minetest_game and many derivatives
 
@@ -49,7 +49,24 @@ and [simple_skins] by TenPlus1.
 Armor can be configured by adding a file called armor.conf in 3d_armor mod or world directory.
 see armor.conf.example for all available options.
 
-For mod installation instructions, please visit: http://wiki.minetest.com/wiki/Installing_Mods
+For **mod installation** instructions, please visit: http://wiki.minetest.com/wiki/Installing_Mods
+
+The specific "armors as modpack" refactorization allows anyone to enable/disable any armors they want as mods rather than obscure settings of the past. (See [#78](https://github.com/minetest-mods/3d_armor/commit/9444afd7222a71fc17d40c9793506812d715dcc3) for further explanation.)
+
+Currently, the modpack includes:
+
+- armor_admin
+- armor_bronze
+- armor_cactus
+- armor_crystal
+- armor_diamond
+- armor_gold
+- armor_mithril
+- armor_nether
+- armor_steel
+- armor_wood
+
+as separate armor mods intentionally. All these mods depend on 3d_armor.
 
 [API Reference](https://minetest-mods.github.io/3d_armor/reference/)
 


### PR DESCRIPTION
Update reflects on:
- outdated modpack version deleted as redundant
- MT 5+ version
- the specific "armors as modpack" refactorization

The latter was a little caveat for me as MT server admin as I was not aware of this major change in the modpack design. After an update no armor was available to anybody as all new mods get disabled (entry set to false) by default.