### PR TITLE
The load print patch

### DIFF
--- a/3d_armor/init.lua
+++ b/3d_armor/init.lua
@@ -509,3 +509,6 @@ if armor.config.fire_protect == true then
 		return hp_change
 	end, true)
 end
+
+-- print to log after mod was loaded successfully
+print ("[MOD] 3D Armor loaded")

--- a/3d_armor_ip/init.lua
+++ b/3d_armor_ip/init.lua
@@ -36,3 +36,6 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 		inventory_plus.set_inventory_formspec(player, formspec)
 	end
 end)
+
+-- print to log after mod was loaded successfully
+print ("[MOD] 3D Armor IP loaded")

--- a/3d_armor_sfinv/init.lua
+++ b/3d_armor_sfinv/init.lua
@@ -19,3 +19,6 @@ armor:register_on_update(function(player)
 		sfinv.set_player_inventory_formspec(player)
 	end
 end)
+
+-- print to log after mod was loaded successfully
+print ("[MOD] 3D Armor SF Inv loaded")

--- a/3d_armor_stand/init.lua
+++ b/3d_armor_stand/init.lua
@@ -353,3 +353,6 @@ minetest.register_craft({
 		{"3d_armor_stand:armor_stand", "default:steel_ingot"},
 	}
 })
+
+-- print to log after mod was loaded successfully
+print ("[MOD] 3D Armor Stand loaded")

--- a/3d_armor_ui/init.lua
+++ b/3d_armor_ui/init.lua
@@ -59,3 +59,6 @@ unified_inventory.register_page("armor", {
 		return {formspec=formspec}
 	end,
 })
+
+-- print to log after mod was loaded successfully
+print ("[MOD] 3D Armor UI loaded")

--- a/armor_admin/init.lua
+++ b/armor_admin/init.lua
@@ -92,3 +92,6 @@ minetest.register_alias("adminboots", "3d_armor:boots_admin")
 minetest.register_alias("adminhelmet", "3d_armor:helmet_admin")
 minetest.register_alias("adminchestplate", "3d_armor:chestplate_admin")
 minetest.register_alias("adminleggings", "3d_armor:leggings_admin")
+
+-- print to log after mod was loaded successfully
+print ("[MOD] 3D Armor - Armor Admin loaded")

--- a/armor_bronze/init.lua
+++ b/armor_bronze/init.lua
@@ -179,3 +179,6 @@ if armor.materials.bronze then
 		},
 	})
 end
+
+-- print to log after mod was loaded successfully
+print ("[MOD] 3D Armor - Armor Bronze loaded")

--- a/armor_cactus/init.lua
+++ b/armor_cactus/init.lua
@@ -181,3 +181,6 @@ if armor.materials.cactus then
 		},
 	})
 end
+
+-- print to log after mod was loaded successfully
+print ("[MOD] 3D Armor - Armor Cactus loaded")

--- a/armor_crystal/init.lua
+++ b/armor_crystal/init.lua
@@ -168,3 +168,6 @@ if armor.materials.crystal then
 		},
 	})
 end
+
+-- print to log after mod was loaded successfully
+print ("[MOD] 3D Armor - Armor Crystal loaded")

--- a/armor_diamond/init.lua
+++ b/armor_diamond/init.lua
@@ -164,3 +164,6 @@ if armor.materials.diamond then
 		},
 	})
 end
+
+-- print to log after mod was loaded successfully
+print ("[MOD] 3D Armor - Armor Diamond loaded")

--- a/armor_gold/init.lua
+++ b/armor_gold/init.lua
@@ -181,3 +181,6 @@ if armor.materials.gold then
 		},
 	})
 end
+
+-- print to log after mod was loaded successfully
+print ("[MOD] 3D Armor - Armor Gold loaded")

--- a/armor_mithril/init.lua
+++ b/armor_mithril/init.lua
@@ -160,3 +160,6 @@ if armor.materials.mithril then
 		},
 	})
 end
+
+-- print to log after mod was loaded successfully
+print ("[MOD] 3D Armor - Armor Mithril loaded")

--- a/armor_nether/init.lua
+++ b/armor_nether/init.lua
@@ -166,3 +166,6 @@ if armor.materials.nether then
 	})
 
 end
+
+-- print to log after mod was loaded successfully
+print ("[MOD] 3D Armor - Armor Nether loaded")

--- a/armor_steel/init.lua
+++ b/armor_steel/init.lua
@@ -179,3 +179,6 @@ if armor.materials.steel then
 		},
 	})
 end
+
+-- print to log after mod was loaded successfully
+print ("[MOD] 3D Armor - Armor Steel loaded")

--- a/armor_wood/init.lua
+++ b/armor_wood/init.lua
@@ -184,3 +184,6 @@ if armor.materials.wood then
 		},
 	})
 end
+
+-- print to log after mod was loaded successfully
+print ("[MOD] 3D Armor - Armor Wood loaded")

--- a/shields/init.lua
+++ b/shields/init.lua
@@ -409,3 +409,6 @@ for k, v in pairs(armor.materials) do
 		},
 	})
 end
+
+-- print to log after mod was loaded successfully
+print ("[MOD] 3D Armor - Shields loaded")

--- a/wieldview/init.lua
+++ b/wieldview/init.lua
@@ -75,3 +75,6 @@ minetest.register_globalstep(function(dtime)
 		time = 0
 	end
 end)
+
+-- print to log after mod was loaded successfully
+print ("[MOD] 3D Armor - Wield View  loaded")


### PR DESCRIPTION
Add a final **print to log** at the end to each `init.lua` to indicate the respective mod was loaded successfully. This idea was derived from other mods which are specifically aimed at MT servers.

The amended code should be similar to this code snippet for all mods respectively within the 3D armor modpack:
```
-- print to log after mod was loaded successfully
print ("[MOD] 3D Armor - Armor XXX loaded")
```

This would not only be useful for player support (e.g. in the MT forum) but would be certainly useful for MT server admins using the CLI and reading their server logs.

EDIT: However, see my additional commentary below.