### PR TITLE
improved load print patch

### DIFF
--- a/3d_armor/init.lua
+++ b/3d_armor/init.lua
@@ -509,3 +509,11 @@ if armor.config.fire_protect == true then
 		return hp_change
 	end, true)
 end
+
+-- print to log after mod was loaded successfully
+local load_message = "[MOD] 3D Armor loaded"
+if minetest.log then
+	minetest.log("info", load_message) -- aims at state of the art MT software
+else
+	print (load_message)  -- aims at legacy MT software used in the field
+end

--- a/3d_armor_ip/init.lua
+++ b/3d_armor_ip/init.lua
@@ -36,3 +36,11 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 		inventory_plus.set_inventory_formspec(player, formspec)
 	end
 end)
+
+-- print to log after mod was loaded successfully
+local load_message = "[MOD] 3D Armor IP loaded"
+if minetest.log then
+	minetest.log("info", load_message) -- aims at state of the art MT software
+else
+	print (load_message)  -- aims at legacy MT software used in the field
+end

--- a/3d_armor_sfinv/init.lua
+++ b/3d_armor_sfinv/init.lua
@@ -19,3 +19,11 @@ armor:register_on_update(function(player)
 		sfinv.set_player_inventory_formspec(player)
 	end
 end)
+
+-- print to log after mod was loaded successfully
+local load_message = "[MOD] 3D Armor SF Inv loaded"
+if minetest.log then
+	minetest.log("info", load_message) -- aims at state of the art MT software
+else
+	print (load_message)  -- aims at legacy MT software used in the field
+end

--- a/3d_armor_stand/init.lua
+++ b/3d_armor_stand/init.lua
@@ -353,3 +353,11 @@ minetest.register_craft({
 		{"3d_armor_stand:armor_stand", "default:steel_ingot"},
 	}
 })
+
+-- print to log after mod was loaded successfully
+local load_message = "[MOD] 3D Armor Stand loaded"
+if minetest.log then
+	minetest.log("info", load_message) -- aims at state of the art MT software
+else
+	print (load_message)  -- aims at legacy MT software used in the field
+end

--- a/3d_armor_ui/init.lua
+++ b/3d_armor_ui/init.lua
@@ -59,3 +59,11 @@ unified_inventory.register_page("armor", {
 		return {formspec=formspec}
 	end,
 })
+
+-- print to log after mod was loaded successfully
+local load_message = "[MOD] 3D Armor UI loaded"
+if minetest.log then
+	minetest.log("info", load_message) -- aims at state of the art MT software
+else
+	print (load_message)  -- aims at legacy MT software used in the field
+end

--- a/armor_admin/init.lua
+++ b/armor_admin/init.lua
@@ -92,3 +92,11 @@ minetest.register_alias("adminboots", "3d_armor:boots_admin")
 minetest.register_alias("adminhelmet", "3d_armor:helmet_admin")
 minetest.register_alias("adminchestplate", "3d_armor:chestplate_admin")
 minetest.register_alias("adminleggings", "3d_armor:leggings_admin")
+
+-- print to log after mod was loaded successfully
+local load_message = "[MOD] 3D Armor - Armor Admin loaded"
+if minetest.log then
+	minetest.log("info", load_message) -- aims at state of the art MT software
+else
+	print (load_message)  -- aims at legacy MT software used in the field
+end

--- a/armor_bronze/init.lua
+++ b/armor_bronze/init.lua
@@ -179,3 +179,11 @@ if armor.materials.bronze then
 		},
 	})
 end
+
+-- print to log after mod was loaded successfully
+local load_message = "[MOD] 3D Armor - Armor Bronze loaded"
+if minetest.log then
+	minetest.log("info", load_message) -- aims at state of the art MT software
+else
+	print (load_message)  -- aims at legacy MT software used in the field
+end

--- a/armor_cactus/init.lua
+++ b/armor_cactus/init.lua
@@ -181,3 +181,11 @@ if armor.materials.cactus then
 		},
 	})
 end
+
+-- print to log after mod was loaded successfully
+local load_message = "[MOD] 3D Armor - Armor Cactus loaded"
+if minetest.log then
+	minetest.log("info", load_message) -- aims at state of the art MT software
+else
+	print (load_message)  -- aims at legacy MT software used in the field
+end

--- a/armor_crystal/init.lua
+++ b/armor_crystal/init.lua
@@ -168,3 +168,11 @@ if armor.materials.crystal then
 		},
 	})
 end
+
+-- print to log after mod was loaded successfully
+local load_message = "[MOD] 3D Armor - Armor Crystal loaded"
+if minetest.log then
+	minetest.log("info", load_message) -- aims at state of the art MT software
+else
+	print (load_message)  -- aims at legacy MT software used in the field
+end

--- a/armor_diamond/init.lua
+++ b/armor_diamond/init.lua
@@ -164,3 +164,11 @@ if armor.materials.diamond then
 		},
 	})
 end
+
+-- print to log after mod was loaded successfully
+local load_message = "[MOD] 3D Armor - Armor Diamond loaded"
+if minetest.log then
+	minetest.log("info", load_message) -- aims at state of the art MT software
+else
+	print (load_message)  -- aims at legacy MT software used in the field
+end

--- a/armor_gold/init.lua
+++ b/armor_gold/init.lua
@@ -181,3 +181,11 @@ if armor.materials.gold then
 		},
 	})
 end
+
+-- print to log after mod was loaded successfully
+local load_message = "[MOD] 3D Armor - Armor Gold loaded"
+if minetest.log then
+	minetest.log("info", load_message) -- aims at state of the art MT software
+else
+	print (load_message)  -- aims at legacy MT software used in the field
+end

--- a/armor_mithril/init.lua
+++ b/armor_mithril/init.lua
@@ -160,3 +160,11 @@ if armor.materials.mithril then
 		},
 	})
 end
+
+-- print to log after mod was loaded successfully
+local load_message = "[MOD] 3D Armor - Armor Mithril loaded"
+if minetest.log then
+	minetest.log("info", load_message) -- aims at state of the art MT software
+else
+	print (load_message)  -- aims at legacy MT software used in the field
+end

--- a/armor_nether/init.lua
+++ b/armor_nether/init.lua
@@ -166,3 +166,11 @@ if armor.materials.nether then
 	})
 
 end
+
+-- print to log after mod was loaded successfully
+local load_message = "[MOD] 3D Armor - Armor Nether loaded"
+if minetest.log then
+	minetest.log("info", load_message) -- aims at state of the art MT software
+else
+	print (load_message)  -- aims at legacy MT software used in the field
+end

--- a/armor_steel/init.lua
+++ b/armor_steel/init.lua
@@ -179,3 +179,11 @@ if armor.materials.steel then
 		},
 	})
 end
+
+-- print to log after mod was loaded successfully
+local load_message = "[MOD] 3D Armor - Armor Steel loaded"
+if minetest.log then
+	minetest.log("info", load_message) -- aims at state of the art MT software
+else
+	print (load_message)  -- aims at legacy MT software used in the field
+end

--- a/armor_wood/init.lua
+++ b/armor_wood/init.lua
@@ -184,3 +184,11 @@ if armor.materials.wood then
 		},
 	})
 end
+
+-- print to log after mod was loaded successfully
+local load_message = "[MOD] 3D Armor - Armor Wood loaded"
+if minetest.log then
+	minetest.log("info", load_message) -- aims at state of the art MT software
+else
+	print (load_message)  -- aims at legacy MT software used in the field
+end

--- a/shields/init.lua
+++ b/shields/init.lua
@@ -409,3 +409,11 @@ for k, v in pairs(armor.materials) do
 		},
 	})
 end
+
+-- print to log after mod was loaded successfully
+local load_message = "[MOD] 3D Armor - Shields loaded"
+if minetest.log then
+	minetest.log("info", load_message) -- aims at state of the art MT software
+else
+	print (load_message)  -- aims at legacy MT software used in the field
+end

--- a/wieldview/init.lua
+++ b/wieldview/init.lua
@@ -75,3 +75,11 @@ minetest.register_globalstep(function(dtime)
 		time = 0
 	end
 end)
+
+-- print to log after mod was loaded successfully
+local load_message = "[MOD] 3D Armor - Wieldview loaded"
+if minetest.log then
+	minetest.log("info", load_message) -- aims at state of the art MT software
+else
+	print (load_message)  -- aims at legacy MT software used in the field
+end


### PR DESCRIPTION
From the start my prior PR was aiming at compatibility with legacy clients and servers. If you scan the MT forum you will become aware that there seem to be quite many MT 0.4 servers around which are actively used by many players.

However, only after commiting that PR #95 another project kindly made me aware of the `minetest.log` function, which presumably is a somewhat newer MT core dev invention.  Accordingly, the best solution may be this example of a new piece of improved code, if I understand the MT Lua code correctly.

```
-- print to log after mod was loaded successfully
local load_message = "[MOD] XXX loaded"
if minetest.log then
	minetest.log("info", load_message) -- aims at state of the art MT software
else
	print (load_message)  -- aims at legacy MT software used in the field
end

```

Furthermore, all the 17 files are comprised by one commit now, after I took the opportunity to (again) install the GitHub Desktop App i.e. program on my computer.

Hope this helps.