### PR TITLE
Enhance the admin boots (double speed)

### DIFF
--- a/armor_admin/init.lua
+++ b/armor_admin/init.lua
@@ -81,7 +81,7 @@ armor:register_armor(":3d_armor:boots_admin", {
 	description = S("Admin Boots"),
 	inventory_image = "3d_armor_inv_boots_admin.png",
 	armor_groups = {fleshy=100},
-	groups = {armor_feet=1, armor_heal=100, armor_use=0,
+	groups = {armor_feet=1, armor_heal=100, armor_use=0, physics_speed=1,
 			not_in_creative_inventory=1},
 	on_drop = function(itemstack, dropper, pos)
 		return


### PR DESCRIPTION
If you have the fly priv, you may have noticed that even with fast it can be still painful to cover larger areas - having double speed for the admin boots helps admins a lot there!

(If you don't want more speed you can only use other admin armor pieces without effects while still having heal>=100.)