### PR TITLE
Tweak Esperanto translation

### DIFF
--- a/3d_armor/locale/3d_armor.eo.tr
+++ b/3d_armor/locale/3d_armor.eo.tr
@@ -1,7 +1,7 @@
 # textdomain: 3d_armor
 Radiation=Radiado
 Level=Nivelo
-Heal=Sanigi
+Heal=Blokŝanco
 Fire=Fajro
 Your @1 is almost broken!=Via @1 estas preskaŭ rompita!
 Your @1 got destroyed!=Via @1 detruiĝis!

--- a/3d_armor_ip/locale/3d_armor_ip.eo.tr
+++ b/3d_armor_ip/locale/3d_armor_ip.eo.tr
@@ -1,3 +1,3 @@
 # textdomain: 3d_armor_ip
 Back=Dorso
-Armor=Kiraso
+Armor=Armaĵo

--- a/3d_armor_sfinv/locale/3d_armor_sfinv.eo.tr
+++ b/3d_armor_sfinv/locale/3d_armor_sfinv.eo.tr
@@ -1,2 +1,2 @@
 # textdomain: 3d_armor_sfinv
-Armor=Kiraso
+Armor=Armaĵoj

--- a/3d_armor_stand/locale/3d_armor_stand.eo.tr
+++ b/3d_armor_stand/locale/3d_armor_stand.eo.tr
@@ -1,5 +1,5 @@
 # textdomain: 3d_armor_stand
-Armor Stand Top=Kirasstando Supro
-Armor Stand=Kirasstando
-Locked Armor Stand=Ŝlosita Kirasstando
-Armor Stand (owned by @1)=Kirasstando (posedata de @1)
+Armor Stand Top=Armaĵtenila Supro
+Armor Stand=Armaĵtenilo
+Locked Armor Stand=Ŝlosita Armaĵtenilo
+Armor Stand (owned by @1)=Ŝlosita Armaĵtenilo (posedata de @1)

--- a/3d_armor_ui/locale/3d_armor_ui.eo.tr
+++ b/3d_armor_ui/locale/3d_armor_ui.eo.tr
@@ -1,7 +1,7 @@
 # textdomain: 3d_armor_ui
-3D Armor=3D Kiraso
-Armor not initialized!=Kiraso ne pravigita!
-Armor=Kiraso
+3D Armor=3D Armaĵoj
+Armor not initialized!=Armaĵoj ne pretigitaj!
+Armor=Armaĵo
 Level=Nivelo
 Heal=Sanigi
 Fire=Fajro

--- a/armor_admin/locale/armor_admin.eo.tr
+++ b/armor_admin/locale/armor_admin.eo.tr
@@ -1,5 +1,5 @@
 # textdomain: armor_admin
 Admin Helmet=Administra Kasko
-Admin Chestplate=Administra Brustkiraso
+Admin Chestplate=Administra Kiraso
 Admin Leggings=Administra Pantalono
-Admin Boots=Administra Botoj
+Admin Boots=Administraj Botoj

--- a/armor_bronze/locale/armor_bronze.eo.tr
+++ b/armor_bronze/locale/armor_bronze.eo.tr
@@ -1,5 +1,5 @@
 # textdomain: armor_bronze
 Bronze Helmet=Bronza Kasko
-Bronze Chestplate=Bronza Brustkiraso
+Bronze Chestplate=Bronza Kiraso
 Bronze Leggings=Bronza Pantalono
-Bronze Boots=Bronza Botoj
+Bronze Boots=Bronzaj Botoj

--- a/armor_cactus/locale/armor_cactus.eo.tr
+++ b/armor_cactus/locale/armor_cactus.eo.tr
@@ -1,5 +1,5 @@
 # textdomain: armor_cactus
 Cactus Helmet=Kakta Kasko
-Cactus Chestplate=Kakta Brustkiraso
+Cactus Chestplate=Kakta Kiraso
 Cactus Leggings=Kakta Pantalono
-Cactus Boots=Kakta Botoj
+Cactus Boots=Kaktaj Botoj

--- a/armor_crystal/locale/armor_crystal.eo.tr
+++ b/armor_crystal/locale/armor_crystal.eo.tr
@@ -1,5 +1,5 @@
 # textdomain: armor_crystal
 Crystal Helmet=Kristala Kasko
-Crystal Chestplate=Kristala Brustkiraso
+Crystal Chestplate=Kristala Kiraso
 Crystal Leggings=Kristala Pantalono
-Crystal Boots=Kristala Botoj
+Crystal Boots=Kristalaj Botoj

--- a/armor_diamond/locale/armor_diamond.eo.tr
+++ b/armor_diamond/locale/armor_diamond.eo.tr
@@ -1,5 +1,5 @@
 # textdomain: armor_diamond
 Diamond Helmet=Diamanta Kasko
-Diamond Chestplate=Diamanta Brustkiraso
+Diamond Chestplate=Diamanta Kiraso
 Diamond Leggings=Diamanta Pantalono
-Diamond Boots=Diamanta Botoj
+Diamond Boots=Diamantaj Botoj

--- a/armor_gold/locale/armor_gold.eo.tr
+++ b/armor_gold/locale/armor_gold.eo.tr
@@ -1,5 +1,5 @@
 # textdomain: armor_gold
 Gold Helmet=Ora Kasko
-Gold Chestplate=Ora Brustkiraso
+Gold Chestplate=Ora Kiraso
 Gold Leggings=Ora Pantalono
-Gold Boots=Ora Botoj
+Gold Boots=Oraj Botoj

--- a/armor_mithril/locale/armor_mithril.eo.tr
+++ b/armor_mithril/locale/armor_mithril.eo.tr
@@ -1,5 +1,5 @@
 # textdomain: armor_mithril
 Mithril Helmet=Mitrila Kasko
-Mithril Chestplate=Mitrila Brustkiraso
+Mithril Chestplate=Mitrila Kiraso
 Mithril Leggings=Mitrila Pantalono
-Mithril Boots=Mitrila Botoj
+Mithril Boots=Mitrilaj Botoj

--- a/armor_nether/locale/armor_nether.eo.tr
+++ b/armor_nether/locale/armor_nether.eo.tr
@@ -1,5 +1,5 @@
 # textdomain: armor_nether
 Nether Helmet=Inferna Kasko
-Nether Chestplate=Inferna Brustkiraso
+Nether Chestplate=Inferna Kiraso
 Nether Leggings=Inferna Pantalono
-Nether Boots=Inferna Botoj
+Nether Boots=Infernaj Botoj

--- a/armor_steel/locale/armor_steel.eo.tr
+++ b/armor_steel/locale/armor_steel.eo.tr
@@ -1,5 +1,5 @@
 # textdomain: armor_steel
 Steel Helmet=Ŝtala Kasko
-Steel Chestplate=Ŝtala Brustkiraso
+Steel Chestplate=Ŝtala Kiraso
 Steel Leggings=Ŝtala Pantalono
-Steel Boots=Ŝtala Botoj
+Steel Boots=Ŝtalaj Botoj

--- a/armor_wood/locale/armor_wood.eo.tr
+++ b/armor_wood/locale/armor_wood.eo.tr
@@ -1,5 +1,5 @@
 # textdomain: armor_wood
 Wood Helmet=Ligna Kasko
-Wood Chestplate=Ligna Brustkiraso
+Wood Chestplate=Ligna Kiraso
 Wood Leggings=Ligna Pantalono
-Wood Boots=Ligna Botoj
+Wood Boots=Lignaj Botoj


### PR DESCRIPTION
This makes a couple tweaks to the translation:
* Changes the translation for “Armor” from [“Kiraso”](https://www.akademio-de-esperanto.org/fundamento/universala_vortaro.html#av-2065) (Cuirass/Chestplate) to [“Armaĵo”](https://en.wiktionary.org/wiki/arma%C4%B5o) (Armor)
* Changes the translation for “Breastplate” from “[Brust](https://www.akademio-de-esperanto.org/fundamento/universala_vortaro.html#av-595)kiraso” (literally “Chest-cuirass”/“Chest-chestplate”) to “Kiraso” (Chestplate)
* Makes adjectives’ plurality agree with nouns’ plurality
* Changes the translation for “Armor Stand” from “Kiras[stando](https://en.wiktionary.org/wiki/stando)” (“Chestplate-booth”) to “Armaĵtenilo” (“Armor-holder”).

Cheers! :)