### PR TITLE
Fix "player still online" check of `armor.unequip`

### DIFF
--- a/3d_armor/api.lua
+++ b/3d_armor/api.lua
@@ -719,13 +719,14 @@ armor.unequip = function(self, player, armor_element)
 		if self:get_element(stack:get_name()) == armor_element then
 			armor_inv:set_stack("armor", i, "")
 			minetest.after(0, function()
-				-- resolve player object again in async function
-				player = minetest.get_player_by_name(name)
-				local inv = player:get_inventory()
-				if inv:room_for_item("main", stack) then
-					inv:add_item("main", stack)
-				else
-					minetest.add_item(player:get_pos(), stack)
+				local pplayer = minetest.get_player_by_name(name)
+				if pplayer then -- player is still online
+					local inv = pplayer:get_inventory()
+					if inv:room_for_item("main", stack) then
+						inv:add_item("main", stack)
+					else
+						minetest.add_item(pplayer:get_pos(), stack)
+					end
 				end
 			end)
 			self:run_callbacks("on_unequip", player, i, stack)


### PR DESCRIPTION
Fixes https://github.com/minetest-mods/3d_armor/issues/132, https://gitea.your-land.de/your-land/bugtracker/issues/5978
- Fix player still online check inside of `minetest.after()` call
- The `pplayer` var name is used in other after calls of 3d_armor too, I used this for consistency


@\merger: Feel free to invent a better commit msg :smile: 