### PR TITLE
Fix crash when right-clicking to equip a seventh armor element with a full armor inventory

### DIFF
--- a/3d_armor/api.lua
+++ b/3d_armor/api.lua
@@ -694,6 +694,9 @@ armor.equip = function(self, player, itemstack)
 				index = i
 			end
 		end
+		if not index then -- armor inventory is full with other armor elements
+			return itemstack
+		end
 		local stack = itemstack:take_item()
 		armor_inv:set_stack("armor", index, stack)
 		self:run_callbacks("on_equip", player, index, stack)


### PR DESCRIPTION
If a player has a full armor inventory then attempts to equip a seventh armor item with a new armor element via right-click, this will cause the game to crash. This fix adds a check after the armor inventory scan in `armor.equip` such that if the empty armor index is nil (indicating a full armor inventory), then the function simply returns and has no effect.

This issue was originally reported as [an issue on Astralcraft](https://github.com/EmptyStar/astralcraft/issues/2) where more details are available including my steps to reproduce, my findings, and more info about my fix.