### PR TITLE
Ability to use empty textures

### DIFF
--- a/3d_armor/README.md
+++ b/3d_armor/README.md
@@ -160,8 +160,8 @@ Wrapper function for `minetest.register_tool`, which enables the easy registrati
 
 ### Additional fields supported by 3d_armor
 
-	texture = <filename>
-	preview = <filename>
+	texture = <filename> (nil for generated texture name, "" for no texture or custom filename)
+	preview = <filename> (nil for generated texture name, "" for no texture or custom filename)
 	armor_groups = <table>
 	damage_groups = <table>
 	reciprocate_damage = <bool>

--- a/3d_armor/api.lua
+++ b/3d_armor/api.lua
@@ -420,16 +420,20 @@ armor.set_player_armor = function(self, player)
 				end
 			end
 			local item = stack:get_name()
-			local tex = def.texture or item:gsub("%:", "_")
-			tex = tex:gsub(".png$", "")
-			if def.preview ~= "" then
-				local prev = def.preview or tex.."_preview"
-				prev = prev:gsub(".png$", "")
-				preview = preview.."^"..prev..".png"
+			local tex
+			if def.texture ~= "" then
+				tex = def.texture or item:gsub("%:", "_")
+				tex = tex:gsub(".png$", "")
 			end
-			if not transparent_armor or def.armor_texture ~= "" then
-				local armtex = def.armor_texture or tex .. ".png"
-				texture = texture .. "^" .. armtex
+			if def.preview ~= "" then
+				local prev = def.preview or tex and tex.."_preview"
+				if prev then
+					prev = prev:gsub(".png$", "")
+					preview = preview.."^"..prev..".png"
+				end
+			end
+			if not transparent_armor and tex then
+				texture = texture .. "^" .. tex .. ".png"
 			end
 			state = state + stack:get_wear()
 			count = count + 1

--- a/3d_armor/api.lua
+++ b/3d_armor/api.lua
@@ -422,12 +422,15 @@ armor.set_player_armor = function(self, player)
 			local item = stack:get_name()
 			local tex = def.texture or item:gsub("%:", "_")
 			tex = tex:gsub(".png$", "")
-			local prev = def.preview or tex.."_preview"
-			prev = prev:gsub(".png$", "")
-			if not transparent_armor then
-				texture = texture.."^"..tex..".png"
+			if def.preview ~= "" then
+				local prev = def.preview or tex.."_preview"
+				prev = prev:gsub(".png$", "")
+				preview = preview.."^"..prev..".png"
 			end
-			preview = preview.."^"..prev..".png"
+			if not transparent_armor or def.armor_texture ~= "" then
+				local armtex = def.armor_texture or tex .. ".png"
+				texture = texture .. "^" .. armtex
+			end
 			state = state + stack:get_wear()
 			count = count + 1
 			for _, phys in pairs(self.physics) do

--- a/3d_armor/api.lua
+++ b/3d_armor/api.lua
@@ -421,6 +421,7 @@ armor.set_player_armor = function(self, player)
 			end
 			local item = stack:get_name()
 			local tex
+			-- Allow empty texture names for convenience
 			if def.texture ~= "" then
 				tex = def.texture or item:gsub("%:", "_")
 				tex = tex:gsub(".png$", "")


### PR DESCRIPTION
This pull adds the ability to set 'texture' and 'preview' in armor registration to "" so that items will not require a texture to be added or shown.