### PR TITLE
Stop chat spamming on break

### DIFF
--- a/3d_armor/init.lua
+++ b/3d_armor/init.lua
@@ -106,20 +106,17 @@ armor.formspec = armor.formspec..
 if armor.config.fire_protect then
 	armor.formspec = armor.formspec.."label[5,2;"..F(S("Fire"))..": armor_attr_fire]"
 end
+local players_warned = {}
 armor:register_on_damage(function(player, index, stack)
 	local name = player:get_player_name()
 	local def = stack:get_definition()
 	if name and def and def.description and stack:get_wear() > 60100 then
-		-- Don't spam armor break message
-		local itemmeta = stack:get_meta()
-		local last_msg_time = tonumber(itemmeta:get_string("last_msg_time")) or 0
-		local curr_time = core.get_us_time() / 1000000 -- seconds
-		if curr_time - last_msg_time >= 10 then
+		local tname = name .. " " .. stack:get_name()
+		if not players_warned[tname] then
+			players_warned[tname] = true
 			minetest.chat_send_player(name, S("Your @1 is almost broken!", def.description))
-			itemmeta:set_string("last_msg_time", tostring(curr_time))
+			core.after(8, function() players_warned[tname] = nil end)
 		end
-		minetest.sound_play("default_tool_breaks", {to_player = name, gain = 2.0}, true)
-	end
 end)
 armor:register_on_destroy(function(player, index, stack)
 	local name = player:get_player_name()

--- a/3d_armor/init.lua
+++ b/3d_armor/init.lua
@@ -117,6 +117,8 @@ armor:register_on_damage(function(player, index, stack)
 			minetest.chat_send_player(name, S("Your @1 is almost broken!", def.description))
 			core.after(8, function() players_warned[tname] = nil end)
 		end
+		minetest.sound_play("default_tool_breaks", {to_player = name, gain = 2.0}, true)
+	end
 end)
 armor:register_on_destroy(function(player, index, stack)
 	local name = player:get_player_name()

--- a/3d_armor/init.lua
+++ b/3d_armor/init.lua
@@ -110,8 +110,15 @@ armor:register_on_damage(function(player, index, stack)
 	local name = player:get_player_name()
 	local def = stack:get_definition()
 	if name and def and def.description and stack:get_wear() > 60100 then
-		minetest.chat_send_player(name, S("Your @1 is almost broken!", def.description))
-		minetest.sound_play("default_tool_breaks", {to_player = name, gain = 2.0})
+		-- Don't spam armor break message
+		local itemmeta = stack:get_meta()
+		local last_msg_time = tonumber(itemmeta:get_string("last_msg_time")) or 0
+		local curr_time = core.get_us_time() / 1000000 -- seconds
+		if curr_time - last_msg_time >= 10 then
+			minetest.chat_send_player(name, S("Your @1 is almost broken!", def.description))
+			itemmeta:set_string("last_msg_time", tostring(curr_time))
+		end
+		minetest.sound_play("default_tool_breaks", {to_player = name, gain = 2.0}, true)
 	end
 end)
 armor:register_on_destroy(function(player, index, stack)


### PR DESCRIPTION
Add a simple per-item second counter to stop armor break messages from spamming chat.